### PR TITLE
Add support for running releases locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,45 @@
 `promote-release` is the tool used by the Rust project to publish new releases
 of the Rust toolchain.
 
+## Running the tool locally
+
+It's possible to run the `promote-release` tool locally without access to any
+production credential, to ease testing changes made to it. You need to make
+sure to have `docker` and `docker-compose` installed on your local system, and
+you need to start the local environment by running:
+
+```
+docker-compose up
+```
+
+This will start an instance of [MinIO](https://min.io) and build a local
+container tailored to run the release process on. Once the local environment is
+up and running, you can start a release with one of the following commands:
+
+```
+./run.sh nightly
+./run.sh beta
+./run.sh stable
+```
+
+Once the release is done, you can use it with `rustup` by setting the following
+environment variable while calling `rustup`:
+
+```
+RUSTUP_DIST_SERVER="http://localhost:9000/static"
+```
+
+### Adding additional files to the local release
+
+To save on time and bandwidth, when running a release locally the tooling won't
+include all files present in a proper release, but to save on bandwidth and
+storage only a small subset of it is included (on 2020-09-16 a full release
+weights 27GB).
+
+You can add additional files by tweaking the environment variables in
+`local/run.sh`.
+
+## License
+
 The contents of this repository are licensed under both the MIT and the Apache
 2.0 license, allowing you to choose which one to adhere to.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ weights 27GB).
 You can add additional files by tweaking the environment variables in
 `local/run.sh`.
 
+### Inspecting the contents of the object storage
+
+You can access the contents of the object storage by visiting
+<http://localhost:9000/minio> and logging in with:
+
+* Access Key: `access_key`
+* Secret Key: `secret_key`
+
 ## License
 
 The contents of this repository are licensed under both the MIT and the Apache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+---
+version: '3'
+
+services:
+  minio:
+    image: minio/minio
+    command: minio server /data
+    ports:
+      - 9000:9000
+    volumes:
+      - minio-data:/data
+    environment:
+      MINIO_ACCESS_KEY: access_key
+      MINIO_SECRET_KEY: secret_key
+
+  local:
+    build: local
+    depends_on:
+      - minio
+    command: /src/local/idle.sh
+    volumes:
+      - .:/src
+      - local-data:/persistent
+
+volumes:
+  minio-data: {}
+  local-data: {}

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,0 +1,33 @@
+# Container image to run the release process on. This is meant to be used
+# locally, and should not be relied upon for production.
+
+# Downloading the `mc` client from dl.min.io is unbearably slow from Europe (it
+# regularly takes 2 minutes to download 20MB of binary). The only other way
+# they distribute the CLI is from Docker, so we load their image as a stage and
+# then copy the binary from it later in the build.
+FROM minio/mc AS mc
+
+FROM ubuntu:focal
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    awscli \
+    curl \
+    git \
+    gnupg \
+    jq \
+    python3 \
+    socat
+
+# Dependencies needed to run ./x.py hash-and-dist
+# These should not be needed anymore once we stop calling it through ./x.py
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential \
+    cmake \
+    ninja-build \
+    python-is-python3
+
+COPY --from=mc /usr/bin/mc /usr/local/bin/mc
+RUN chmod 0755 /usr/local/bin/mc
+
+ENTRYPOINT ["/src/local/setup.sh"]
+CMD ["/src/local/idle.sh"]

--- a/local/channel-rust-dummy.toml
+++ b/local/channel-rust-dummy.toml
@@ -1,0 +1,5 @@
+# This is a dummy channel file to store on the local static bucket when
+# promote-release runs, to force it to do a new release.
+
+[pkg.rust]
+version = "0.0.0-dummy (000000000 1970-01-01)"

--- a/local/generate-gpg-key.conf
+++ b/local/generate-gpg-key.conf
@@ -1,0 +1,9 @@
+Key-Type: RSA
+Key-Length: 2048
+Key-Usage: encrypt,sign,auth
+Passphrase: password
+Name-Email: promote-release@example.com
+Name-Real: promote-release test suite demo key
+Expire-Date: 0
+
+%commit

--- a/local/idle.sh
+++ b/local/idle.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Keep the container alive forever.
+
+while true; do
+    sleep 31536000
+done

--- a/local/run.sh
+++ b/local/run.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# This script is executed at the start of each local release, and prepares the
+# environment by copying the artifacts built by CI on the MinIO instance. Then,
+# it starts promote-release with the right flags.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+RUSTC_REPO="https://github.com/rust-lang/rust"
+RUSTC_DEFAULT_BRANCH="master"
+
+# CDN to download CI artifacts from.
+DOWNLOAD_BASE="https://ci-artifacts.rust-lang.org/rustc-builds"
+# Rustup components to download for each target we want to release.
+DOWNLOAD_COMPONENTS=(
+    "cargo"
+    "rust"
+    "rust-docs"
+    "rust-std"
+    "rustc"
+)
+# Targets to download the components of. *All* the components will be
+# downloaded for each target, so adding more of them might slow down running
+# the release process.
+#
+# Never remove "x86_64-unknown-linux-gnu", as that target is required for the
+# release process to work (promote-release extracts version numbers from it).
+DOWNLOAD_COMPONENT_TARGETS=(
+    "x86_64-unknown-linux-gnu"
+)
+# Files to download that are not rustup components. No mangling is done on the
+# file name, so include its full path.
+DOWNLOAD_STANDALONE=(
+    "toolstates-linux.json"
+)
+
+channel="$1"
+
+# Nightly is on the default branch
+if [[ "${channel}" = "nightly" ]]; then
+    branch="${RUSTC_DEFAULT_BRANCH}"
+else
+    branch="${channel}"
+fi
+
+echo "==> overriding files to force promote-release to run"
+mc cp /src/local/channel-rust-dummy.toml "local/static/dist/channel-rust-${channel}.toml" >/dev/null
+
+echo "==> detecting the last rustc commit on branch ${branch}"
+commit="$(git ls-remote "${RUSTC_REPO}" | grep "refs/heads/${branch}" | awk '{print($1)}')"
+
+download() {
+    file="$1"
+    if ! mc stat "local/artifacts/builds/${commit}/${file}" >/dev/null 2>&1; then
+        echo "==> copying ${file} from ci-artifacts.rust-lang.org"
+        curl -Lo /tmp/component "${DOWNLOAD_BASE}/${commit}/${file}" --fail
+        mc cp /tmp/component "local/artifacts/builds/${commit}/${file}" >/dev/null
+    else
+        echo "==> reusing cached ${file}"
+    fi
+}
+
+for target in "${DOWNLOAD_COMPONENT_TARGETS[@]}"; do
+    for component in "${DOWNLOAD_COMPONENTS[@]}"; do
+        download "${component}-${channel}-${target}.tar.xz"
+    done
+done
+for file in "${DOWNLOAD_STANDALONE[@]}"; do
+    download "${file}"
+done
+
+echo "==> starting promote-release"
+export PROMOTE_RELEASE_SKIP_CLOUDFRONT_INVALIDATIONS=yes
+export PROMOTE_RELEASE_SKIP_DELETE_BUILD_DIR=yes
+/src/target/release/promote-release /persistent/release "${channel}" /src/local/secrets.toml

--- a/local/secrets.toml
+++ b/local/secrets.toml
@@ -1,0 +1,17 @@
+[dist]
+gpg-password-file = "/root/gpg-password"
+
+upload-addr = "http://localhost:9000/static"
+upload-bucket = "static"
+upload-dir = "dist"
+
+download-bucket = "artifacts"
+download-dir = "builds"
+
+aws-access-key-id = "access_key"
+aws-secret-key = "secret_key"
+
+aws-s3-endpoint-url = "http://minio:9000"
+
+cloudfront-distribution-id = "id_static"
+rustdoc-cf-distribution-id = "id_rustdoc"

--- a/local/setup.sh
+++ b/local/setup.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Setup the local container when it boots, configuring access to MinIO and
+# generating a GPG key when needed.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+MINIO_HOST="minio"
+MINIO_PORT="9000"
+MINIO_URL="http://${MINIO_HOST}:${MINIO_PORT}"
+MINIO_ACCESS_KEY="access_key"
+MINIO_SECRET_KEY="secret_key"
+
+MINIO_BUCKETS=( "static" "artifacts" )
+
+# Quit immediately when docker-compose receives a Ctrl+C
+trap SIGTERM exit
+
+# Wait until minio finished loading
+echo "waiting for minio to start"
+while ! curl --silent --fail "${MINIO_URL}/minio/health/cluster"; do
+    sleep 0.1
+done
+echo "minio is now available"
+
+echo "starting a proxy for minio"
+socat "tcp-listen:${MINIO_PORT},reuseaddr,fork" "tcp:${MINIO_HOST}:${MINIO_PORT}" &
+
+# Configure the minio client to talk to the right instance.
+echo "configuring cli access to minio"
+mc alias set local "${MINIO_URL}" "${MINIO_ACCESS_KEY}" "${MINIO_SECRET_KEY}" >/dev/null
+
+# Create and configure minio buckets
+for bucket in "${MINIO_BUCKETS[@]}"; do
+    if ! mc stat "local/${bucket}" >/dev/null 2>&1; then
+        echo "creating the ${bucket} minio bucket"
+        mc mb "local/${bucket}" >/dev/null
+    fi
+    echo "making the ${bucket} minio bucket public"
+    mc policy set download "local/${bucket}" >/dev/null
+done
+
+# Generate the GPG key to sign binaries
+export GNUPGHOME=/persistent/gpg-home
+if ! [[ -d "${GNUPGHOME}" ]]; then
+    mkdir /persistent/gpg-home
+    chmod 0700 /persistent/gpg-home
+fi
+if ! gpg --list-secret-keys 2>/dev/null | grep "promote-release@example.com" >/dev/null 2>&1; then
+    echo "generating a dummy gpg key for signing"
+    echo "password" > /persistent/gpg-password
+    # https://www.gnupg.org/documentation//manuals/gnupg/Unattended-GPG-key-generation.html
+    gpg --batch --gen-key /src/local/generate-gpg-key.conf >/dev/null
+else
+    echo "reusing existing gpg key"
+fi
+
+cat <<EOF
+
+####################################################
+##  Local environment bootstrapped successfully!  ##
+####################################################
+
+To start the release process locally, run either:
+
+    ./run.sh nightly
+    ./run.sh beta
+    ./run.sh stable
+
+To use a release produced locally, set this environment variable when
+interacting with rustup:
+
+    RUSTUP_DIST_SERVER="http://localhost:9000/static"
+
+Press Ctrl-C to stop the local environment.
+
+EOF
+
+$@

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Start a dummy local release process, without making changes to any production
+# system. This requires docker and docker-compose to be installed.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+if [[ "$#" -ne 1 ]]; then
+    echo "Usage: $0 <channel>"
+    exit 1
+fi
+channel="$1"
+
+container_id="$(docker-compose ps -q local)"
+container_status="$(docker inspect "${container_id}" --format "{{.State.Status}}")"
+if [[ "${container_status}" != "running" ]]; then
+    echo "Error: the local environment is not running!"
+    echo "You can start it by running in a new terminal the following command:"
+    echo
+    echo "    docker-compose up"
+    echo
+    exit 1
+fi
+
+# Ensure the release build is done
+cargo build --release
+
+# Run the command inside the docker environment.
+docker-compose exec local /src/local/run.sh "${channel}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,8 +165,13 @@ impl Context {
 
     fn configure_rust(&mut self, rev: &str) -> Result<(), Error> {
         let build = self.build_dir();
-        drop(fs::remove_dir_all(&build));
-        fs::create_dir_all(&build)?;
+        // Avoid deleting the build directory with the cached build artifacts when working locally.
+        if std::env::var("PROMOTE_RELEASE_SKIP_DELETE_BUILD_DIR").is_err() {
+            let _ = fs::remove_dir_all(&build);
+        }
+        if !build.exists() {
+            fs::create_dir_all(&build)?;
+        }
         let rust = self.rust_dir();
 
         run(Command::new("git")

--- a/src/main.rs
+++ b/src/main.rs
@@ -587,6 +587,13 @@ upload-addr = \"{}/{}\"
 
     fn aws_s3(&self) -> Command {
         let mut cmd = Command::new("aws");
+
+        // Allow using non-S3 backends with the AWS CLI.
+        if let Some(url) = &self.secrets.aws_s3_endpoint_url {
+            cmd.arg("--endpoint-url");
+            cmd.arg(url);
+        }
+
         cmd.arg("s3");
         self.aws_creds(&mut cmd);
         return cmd;
@@ -687,6 +694,10 @@ struct DistConfig {
     aws_access_key_id: String,
     /// Secret key of the access key specified above
     aws_secret_key: String,
+
+    /// Custom Endpoint URL for S3. Set this if you want to point to an S3-compatible service
+    /// instead of the AWS one.
+    aws_s3_endpoint_url: Option<String>,
 
     /// CloudFront Distribution ID for static.rust-lang.org
     cloudfront_distribution_id: String,


### PR DESCRIPTION
This PR adds all the tooling necessary to run a release locally without the need of production credentials. The goal is to be able to start a release by running these two commands in two separate terminals:

```
docker-compose up
./run.sh <channel>
```

r? @Mark-Simulacrum 