### PR TITLE
Add CI to the repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+---
+
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the source code
+        uses: actions/checkout@v2
+
+      - name: Ensure Rust Stable is up to date
+        run: rustup self update && rustup update stable
+
+      - name: Ensure the source code is formatted
+        run: cargo fmt -- --check
+
+      - name: Ensure there are no Clippy warnings
+        run: cargo clippy -- -Dwarnings
+
+      - name: Ensure tests are passing
+        run: cargo test
+
+  local:
+    name: Local release
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [stable, beta, nightly]
+
+    steps:
+      - name: Clone the source code
+        uses: actions/checkout@v2
+
+      - name: Ensure Rust Stable is up to date
+        run: rustup self update && rustup update stable
+
+      - name: Start the local environment
+        run: docker-compose up -d
+
+      - name: Run the local release process for channel ${{ matrix.channel }}
+        run: ./run.sh ${{ matrix.channel }}
+
+      - name: Remove the previously installed ${{ matrix.channel }} toolchain
+        run: rustup toolchain remove ${{ matrix.channel }}
+
+      - name: Install the ${{ matrix.channel }} toolchain from the local environment
+        run: rustup toolchain install ${{ matrix.channel }} --profile=minimal
+        env:
+          RUSTUP_DIST_SERVER: http://localhost:9000/static

--- a/local/channel-rust-beta.toml
+++ b/local/channel-rust-beta.toml
@@ -1,0 +1,5 @@
+# This is a dummy channel file to store on the local static bucket when
+# promote-release runs, to force it to do a new release.
+
+[pkg.rust]
+version = "0.0.0-beta.0 (000000000 1970-01-01)"

--- a/local/channel-rust-nightly.toml
+++ b/local/channel-rust-nightly.toml
@@ -1,0 +1,5 @@
+# This is a dummy channel file to store on the local static bucket when
+# promote-release runs, to force it to do a new release.
+
+[pkg.rust]
+version = "0.0.0-nightly (000000000 1970-01-01)"

--- a/local/channel-rust-stable.toml
+++ b/local/channel-rust-stable.toml
@@ -2,4 +2,4 @@
 # promote-release runs, to force it to do a new release.
 
 [pkg.rust]
-version = "0.0.0-dummy (000000000 1970-01-01)"
+version = "0.0.0 (000000000 1970-01-01)"

--- a/local/run.sh
+++ b/local/run.sh
@@ -44,7 +44,7 @@ else
 fi
 
 echo "==> overriding files to force promote-release to run"
-mc cp /src/local/channel-rust-dummy.toml "local/static/dist/channel-rust-${channel}.toml" >/dev/null
+mc cp "/src/local/channel-rust-${channel}.toml" "local/static/dist/channel-rust-${channel}.toml" >/dev/null
 
 echo "==> detecting the last rustc commit on branch ${branch}"
 commit="$(git ls-remote "${RUSTC_REPO}" | grep "refs/heads/${branch}" | awk '{print($1)}')"

--- a/local/run.sh
+++ b/local/run.sh
@@ -70,6 +70,7 @@ for file in "${DOWNLOAD_STANDALONE[@]}"; do
 done
 
 echo "==> starting promote-release"
+export GNUPGHOME=/persistent/gpg-home
 export PROMOTE_RELEASE_SKIP_CLOUDFRONT_INVALIDATIONS=yes
 export PROMOTE_RELEASE_SKIP_DELETE_BUILD_DIR=yes
 /src/target/release/promote-release /persistent/release "${channel}" /src/local/secrets.toml

--- a/local/secrets.toml
+++ b/local/secrets.toml
@@ -1,5 +1,5 @@
 [dist]
-gpg-password-file = "/root/gpg-password"
+gpg-password-file = "/persistent/gpg-password"
 
 upload-addr = "http://localhost:9000/static"
 upload-bucket = "static"

--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,11 @@ fi
 channel="$1"
 
 container_id="$(docker-compose ps -q local)"
-container_status="$(docker inspect "${container_id}" --format "{{.State.Status}}")"
+if [[ "${container_id}" == "" ]]; then
+    container_status="missing"
+else
+    container_status="$(docker inspect "${container_id}" --format "{{.State.Status}}")"
+fi
 if [[ "${container_status}" != "running" ]]; then
     echo "Error: the local environment is not running!"
     echo "You can start it by running in a new terminal the following command:"

--- a/run.sh
+++ b/run.sh
@@ -26,4 +26,4 @@ fi
 cargo build --release
 
 # Run the command inside the docker environment.
-docker-compose exec local /src/local/run.sh "${channel}"
+docker-compose exec -T local /src/local/run.sh "${channel}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,7 @@ upload-addr = \"{}/{}\"
             for entry in archive.entries()? {
                 let entry = entry?;
                 let path = entry.path()?;
-                if let Some(path) = path.iter().skip(1).next() {
+                if let Some(path) = path.iter().nth(1) {
                     if path == Path::new("version") {
                         version_file = Some(entry);
                         break;
@@ -639,7 +639,7 @@ upload-addr = \"{}/{}\"
 
         cmd.arg("s3");
         self.aws_creds(&mut cmd);
-        return cmd;
+        cmd
     }
 
     fn aws_creds(&self, cmd: &mut Command) {


### PR DESCRIPTION
This PR adds a CI pipeline to `promote-release`, which runs both the standard `cargo fmt`/`cargo clippy`/`cargo test` but also a local release for all the channels. Running CI currently takes around 16 minutes, as running local releases from scratch is slow.

The PR can be reviewed commit-by-commit.
r? @Mark-Simulacrum 