### PR TITLE
Recompress tarballs faster on CI and local releases

### DIFF
--- a/local/run.sh
+++ b/local/run.sh
@@ -109,6 +109,7 @@ done
 
 echo "==> starting promote-release"
 export GNUPGHOME=/persistent/gpg-home
+export PROMOTE_RELEASE_GZIP_COMPRESSION_LEVEL=1 # Faster recompressions
 export PROMOTE_RELEASE_SKIP_CLOUDFRONT_INVALIDATIONS=yes
 export PROMOTE_RELEASE_SKIP_DELETE_BUILD_DIR=yes
 /src/target/release/promote-release /persistent/release "${channel}" /src/local/secrets.toml

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ use std::str::FromStr;
 const ENVIRONMENT_VARIABLE_PREFIX: &str = "PROMOTE_RELEASE_";
 
 pub(crate) struct Config {
+    /// The compression level to use when recompressing tarballs with gzip.
+    pub(crate) gzip_compression_level: u32,
     /// Custom name of the branch to start the release process from, instead of the default one.
     pub(crate) override_branch: Option<String>,
     /// Whether to skip invalidating the CloudFront distributions. This is useful when running the
@@ -18,6 +20,7 @@ pub(crate) struct Config {
 impl Config {
     pub(crate) fn from_env() -> Result<Self, Error> {
         Ok(Self {
+            gzip_compression_level: default_env("GZIP_COMPRESSION_LEVEL", 9)?,
             override_branch: maybe_env("OVERRIDE_BRANCH")?,
             skip_cloudfront_invalidations: bool_env("SKIP_CLOUDFRONT_INVALIDATIONS")?,
             skip_delete_build_dir: bool_env("SKIP_DELETE_BUILD_DIR")?,
@@ -40,6 +43,14 @@ where
             anyhow::bail!("environment variable {} is not unicode!", name)
         }
     }
+}
+
+fn default_env<R>(name: &str, default: R) -> Result<R, Error>
+where
+    R: FromStr,
+    Error: From<R::Err>,
+{
+    Ok(maybe_env(name)?.unwrap_or(default))
 }
 
 fn bool_env(name: &str) -> Result<bool, Error> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,47 @@
+use anyhow::{Context, Error};
+use std::env::VarError;
+use std::str::FromStr;
+
+const ENVIRONMENT_VARIABLE_PREFIX: &str = "PROMOTE_RELEASE_";
+
+pub(crate) struct Config {
+    /// Custom name of the branch to start the release process from, instead of the default one.
+    pub(crate) override_branch: Option<String>,
+    /// Whether to skip invalidating the CloudFront distributions. This is useful when running the
+    /// release process locally, without access to the production AWS account.
+    pub(crate) skip_cloudfront_invalidations: bool,
+    /// Whether to avoid deleting the Rust build dir or not. Deleting it will improve the execution
+    /// time, but it will use more disk space.
+    pub(crate) skip_delete_build_dir: bool,
+}
+
+impl Config {
+    pub(crate) fn from_env() -> Result<Self, Error> {
+        Ok(Self {
+            override_branch: maybe_env("OVERRIDE_BRANCH")?,
+            skip_cloudfront_invalidations: bool_env("SKIP_CLOUDFRONT_INVALIDATIONS")?,
+            skip_delete_build_dir: bool_env("SKIP_DELETE_BUILD_DIR")?,
+        })
+    }
+}
+
+fn maybe_env<R>(name: &str) -> Result<Option<R>, Error>
+where
+    R: FromStr,
+    Error: From<R::Err>,
+{
+    match std::env::var(format!("{}{}", ENVIRONMENT_VARIABLE_PREFIX, name)) {
+        Ok(val) => Ok(Some(val.parse().map_err(Error::from).context(format!(
+            "the {} environment variable has invalid content",
+            name
+        ))?)),
+        Err(VarError::NotPresent) => Ok(None),
+        Err(VarError::NotUnicode(_)) => {
+            anyhow::bail!("environment variable {} is not unicode!", name)
+        }
+    }
+}
+
+fn bool_env(name: &str) -> Result<bool, Error> {
+    Ok(maybe_env::<String>(name)?.is_some())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ struct Context {
     work: PathBuf,
     release: String,
     handle: Easy,
-    secrets: DistConfig,
+    secrets: SecretsDist,
     date: String,
     current_version: Option<String>,
 }
@@ -28,7 +28,7 @@ fn main() -> Result<(), Error> {
     Context {
         work: env::current_dir()?.join(env::args_os().nth(1).unwrap()),
         release: env::args().nth(2).unwrap(),
-        secrets: toml::from_str::<Config>(&secrets)?.dist,
+        secrets: toml::from_str::<Secrets>(&secrets)?.dist,
         handle: Easy::new(),
         date: output(Command::new("date").arg("+%Y-%m-%d"))?
             .trim()
@@ -695,13 +695,13 @@ fn output(cmd: &mut Command) -> Result<String, Error> {
 }
 
 #[derive(serde::Deserialize)]
-struct Config {
-    dist: DistConfig,
+struct Secrets {
+    dist: SecretsDist,
 }
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-struct DistConfig {
+struct SecretsDist {
     /// Path to the file containing the password of the gpg key.
     gpg_password_file: String,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,6 +379,7 @@ upload-addr = \"{}/{}\"
             );
             let recompress_start = Instant::now();
 
+            let compression_level = flate2::Compression::new(self.config.gzip_compression_level);
             to_recompress
                 .par_iter()
                 .map(|(xz_path, gz_path)| {
@@ -387,7 +388,7 @@ upload-addr = \"{}/{}\"
                     let xz = File::open(xz_path)?;
                     let mut xz = xz2::read::XzDecoder::new(xz);
                     let gz = File::create(gz_path)?;
-                    let mut gz = flate2::write::GzEncoder::new(gz, flate2::Compression::best());
+                    let mut gz = flate2::write::GzEncoder::new(gz, compression_level);
                     io::copy(&mut xz, &mut gz)?;
 
                     Ok::<(), Error>(())


### PR DESCRIPTION
When `promote-release` currently recompresses tarballs from `.xz` to `.gz`, it uses the best compression level (9), which on my machine takes ~90 seconds to run for the couple of tarballs downloaded during local builds. That's what we want for production, but it's a waste of time for local releases.

This PR adds an environment variable to change the compression level, and sets it to 1 when doing local builds. When the environment variable is missing the highest compression level (9) will be used.

This PR also centralizes parsing environment variables in a new `Config` struct and adds some utilities to make it more ergonomic to parse the environment. Since this is going to run inside a Docker container I'm planning to move all the existing configuration in `secrets.toml` over to environment variables in a future PR.

r? @Mark-Simulacrum 