### PR TITLE
Load configuration from the environment

### DIFF
--- a/local/run.sh
+++ b/local/run.sh
@@ -113,6 +113,7 @@ export GNUPGHOME=/persistent/gpg-home
 # Environment variables also used in prod releases
 export AWS_ACCESS_KEY_ID="access_key"
 export AWS_SECRET_ACCESS_KEY="secret_key"
+export PROMOTE_RELEASE_CHANNEL="${channel}"
 export PROMOTE_RELEASE_CLOUDFRONT_DOC_ID="id_doc_rust_lang_org"
 export PROMOTE_RELEASE_CLOUDFRONT_STATIC_ID="id_static_rust_lang_org"
 export PROMOTE_RELEASE_DOWNLOAD_BUCKET="artifacts"

--- a/local/run.sh
+++ b/local/run.sh
@@ -107,9 +107,23 @@ for file in "${DOWNLOAD_STANDALONE[@]}"; do
     download "${file}"
 done
 
-echo "==> starting promote-release"
+echo "==> configuring the environment"
+# Point to the right GnuPG environment
 export GNUPGHOME=/persistent/gpg-home
-export PROMOTE_RELEASE_GZIP_COMPRESSION_LEVEL=1 # Faster recompressions
-export PROMOTE_RELEASE_SKIP_CLOUDFRONT_INVALIDATIONS=yes
-export PROMOTE_RELEASE_SKIP_DELETE_BUILD_DIR=yes
+# Environment variables also used in prod releases
+export PROMOTE_RELEASE_CLOUDFRONT_DOC_ID="id_doc_rust_lang_org"
+export PROMOTE_RELEASE_CLOUDFRONT_STATIC_ID="id_static_rust_lang_org"
+export PROMOTE_RELEASE_DOWNLOAD_BUCKET="artifacts"
+export PROMOTE_RELEASE_DOWNLOAD_DIR="builds"
+export PROMOTE_RELEASE_GPG_PASSWORD_FILE="/persistent/gpg-password"
+export PROMOTE_RELEASE_UPLOAD_ADDR="http://localhost:9000/static"
+export PROMOTE_RELEASE_UPLOAD_BUCKET="static"
+export PROMOTE_RELEASE_UPLOAD_DIR="dist"
+# Environment variables used only by local releases
+export PROMOTE_RELEASE_GZIP_COMPRESSION_LEVEL="1" # Faster recompressions
+export PROMOTE_RELEASE_S3_ENDPOINT_URL="http://minio:9000"
+export PROMOTE_RELEASE_SKIP_CLOUDFRONT_INVALIDATIONS="yes"
+export PROMOTE_RELEASE_SKIP_DELETE_BUILD_DIR="yes"
+
+echo "==> starting promote-release"
 /src/target/release/promote-release /persistent/release "${channel}" /src/local/secrets.toml

--- a/local/run.sh
+++ b/local/run.sh
@@ -111,6 +111,8 @@ echo "==> configuring the environment"
 # Point to the right GnuPG environment
 export GNUPGHOME=/persistent/gpg-home
 # Environment variables also used in prod releases
+export AWS_ACCESS_KEY_ID="access_key"
+export AWS_SECRET_ACCESS_KEY="secret_key"
 export PROMOTE_RELEASE_CLOUDFRONT_DOC_ID="id_doc_rust_lang_org"
 export PROMOTE_RELEASE_CLOUDFRONT_STATIC_ID="id_static_rust_lang_org"
 export PROMOTE_RELEASE_DOWNLOAD_BUCKET="artifacts"
@@ -126,4 +128,4 @@ export PROMOTE_RELEASE_SKIP_CLOUDFRONT_INVALIDATIONS="yes"
 export PROMOTE_RELEASE_SKIP_DELETE_BUILD_DIR="yes"
 
 echo "==> starting promote-release"
-/src/target/release/promote-release /persistent/release "${channel}" /src/local/secrets.toml
+/src/target/release/promote-release /persistent/release "${channel}"

--- a/local/secrets.toml
+++ b/local/secrets.toml
@@ -1,3 +1,0 @@
-[dist]
-aws-access-key-id = "access_key"
-aws-secret-key = "secret_key"

--- a/local/secrets.toml
+++ b/local/secrets.toml
@@ -1,17 +1,3 @@
 [dist]
-gpg-password-file = "/persistent/gpg-password"
-
-upload-addr = "http://localhost:9000/static"
-upload-bucket = "static"
-upload-dir = "dist"
-
-download-bucket = "artifacts"
-download-dir = "builds"
-
 aws-access-key-id = "access_key"
 aws-secret-key = "secret_key"
-
-aws-s3-endpoint-url = "http://minio:9000"
-
-cloudfront-distribution-id = "id_static"
-rustdoc-cf-distribution-id = "id_rustdoc"

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,10 +5,39 @@ use std::str::FromStr;
 const ENVIRONMENT_VARIABLE_PREFIX: &str = "PROMOTE_RELEASE_";
 
 pub(crate) struct Config {
+    /// CloudFront distribution ID for doc.rust-lang.org.
+    pub(crate) cloudfront_doc_id: String,
+    /// CloudFront distribution ID for static.rust-lang.org.
+    pub(crate) cloudfront_static_id: String,
+    /// The S3 bucket that CI artifacts will be downloaded from.
+    pub(crate) download_bucket: String,
+    /// The S3 directory that CI artifacts will be downloaded from.
+    pub(crate) download_dir: String,
+    /// Path of the file containing the password of the GPG secret key.
+    pub(crate) gpg_password_file: String,
+    /// Remote HTTP host artifacts will be uploaded to. Note that this is *not* the same as what's
+    /// configured in `config.toml` for rustbuild, it's just the *host* that we're uploading to and
+    /// going to be looking at urls from.
+    ///
+    /// This is used in a number of places such as:
+    ///
+    /// * Downloading manifestss * Urls in manifests
+    ///
+    /// and possibly more. Note that most urls end up appending PROMOTE_RELEASE_UPLOAD_DIR to this
+    /// address specified. This address should not have a trailing slash.
+    pub(crate) upload_addr: String,
+    /// The S3 bucket that release artifacts will be uploaded to.
+    pub(crate) upload_bucket: String,
+    /// The S3 directory that release artifacts will be uploaded to.
+    pub(crate) upload_dir: String,
+
     /// The compression level to use when recompressing tarballs with gzip.
     pub(crate) gzip_compression_level: u32,
     /// Custom name of the branch to start the release process from, instead of the default one.
     pub(crate) override_branch: Option<String>,
+    /// Custom Endpoint URL for S3. Set this if you want to point to an S3-compatible service
+    /// instead of the AWS one.
+    pub(crate) s3_endpoint_url: Option<String>,
     /// Whether to skip invalidating the CloudFront distributions. This is useful when running the
     /// release process locally, without access to the production AWS account.
     pub(crate) skip_cloudfront_invalidations: bool,
@@ -20,10 +49,19 @@ pub(crate) struct Config {
 impl Config {
     pub(crate) fn from_env() -> Result<Self, Error> {
         Ok(Self {
+            cloudfront_doc_id: require_env("CLOUDFRONT_DOC_ID")?,
+            cloudfront_static_id: require_env("CLOUDFRONT_STATIC_ID")?,
+            download_bucket: require_env("DOWNLOAD_BUCKET")?,
+            download_dir: require_env("DOWNLOAD_DIR")?,
+            gpg_password_file: require_env("GPG_PASSWORD_FILE")?,
             gzip_compression_level: default_env("GZIP_COMPRESSION_LEVEL", 9)?,
             override_branch: maybe_env("OVERRIDE_BRANCH")?,
+            s3_endpoint_url: maybe_env("S3_ENDPOINT_URL")?,
             skip_cloudfront_invalidations: bool_env("SKIP_CLOUDFRONT_INVALIDATIONS")?,
             skip_delete_build_dir: bool_env("SKIP_DELETE_BUILD_DIR")?,
+            upload_addr: require_env("UPLOAD_ADDR")?,
+            upload_bucket: require_env("UPLOAD_BUCKET")?,
+            upload_dir: require_env("UPLOAD_DIR")?,
         })
     }
 }
@@ -42,6 +80,17 @@ where
         Err(VarError::NotUnicode(_)) => {
             anyhow::bail!("environment variable {} is not unicode!", name)
         }
+    }
+}
+
+fn require_env<R>(name: &str) -> Result<R, Error>
+where
+    R: FromStr,
+    Error: From<R::Err>,
+{
+    match maybe_env(name)? {
+        Some(res) => Ok(res),
+        None => anyhow::bail!("missing environment variable {}", name),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ use std::str::FromStr;
 const ENVIRONMENT_VARIABLE_PREFIX: &str = "PROMOTE_RELEASE_";
 
 pub(crate) struct Config {
+    /// The channel we're currently releasing.
+    pub(crate) channel: String,
     /// CloudFront distribution ID for doc.rust-lang.org.
     pub(crate) cloudfront_doc_id: String,
     /// CloudFront distribution ID for static.rust-lang.org.
@@ -49,6 +51,7 @@ pub(crate) struct Config {
 impl Config {
     pub(crate) fn from_env() -> Result<Self, Error> {
         Ok(Self {
+            channel: require_env("CHANNEL")?,
             cloudfront_doc_id: require_env("CLOUDFRONT_DOC_ID")?,
             cloudfront_static_id: require_env("CLOUDFRONT_STATIC_ID")?,
             download_bucket: require_env("DOWNLOAD_BUCKET")?,


### PR DESCRIPTION
This PR changes `promote-release` to load its configuration from environment variables, instead of a `secrets.toml` text file. This will make it easier to run the tool on AWS CodeBuild.

r? @Mark-Simulacrum 