### PR TITLE
Implement changes following Friday's outage

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,9 @@ pub(crate) struct Config {
     /// The S3 directory that release artifacts will be uploaded to.
     pub(crate) upload_dir: String,
 
+    /// Whether to allow multiple releases on the same channel in the same day or not.
+    pub(crate) allow_multiple_today: bool,
+
     /// The compression level to use when recompressing tarballs with gzip.
     pub(crate) gzip_compression_level: u32,
     /// Custom name of the branch to start the release process from, instead of the default one.
@@ -51,6 +54,7 @@ pub(crate) struct Config {
 impl Config {
     pub(crate) fn from_env() -> Result<Self, Error> {
         Ok(Self {
+            allow_multiple_today: bool_env("ALLOW_MULTIPLE_TODAY")?,
             channel: require_env("CHANNEL")?,
             cloudfront_doc_id: require_env("CLOUDFRONT_DOC_ID")?,
             cloudfront_static_id: require_env("CLOUDFRONT_STATIC_ID")?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -561,10 +561,7 @@ upload-addr = \"{}/{}\"
         self.invalidate_cloudfront(
             &self.config.cloudfront_static_id,
             &[
-                "/dist/channel*".into(),
-                "/dist/rust*".into(),
-                "/dist/index*".into(),
-                "/dist/".into(),
+                "/dist/*".into(),
             ],
         )
     }


### PR DESCRIPTION
This PR implements the changes needed to prevent https://github.com/rust-lang/rustup/issues/2504 from happening again:

* The whole `/dist/*` directory is invalidated in CloudFront instead of the singe manifest file. This will slightly impact cache hits after a release happens, but it will also prevent the root cause of the outage.
* `promote-release` will now refuse to do multiple releases on the same channel on the same day, unless the `PROMOTE_RELEASE_ALLOW_MULTIPLE_TODAY` environment variable is set. I'm not sure we'll ever use the environment variable, but at least it's there if we actually need it.

I'll prepare a backport to the `promote-release` copy in RCS once this PR is merged.
The PR can be reviewed commit-by-commit.

r? @Mark-Simulacrum 