### PR TITLE
Avoid wasting CI artifact storage space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           name: docker-image
           path: promote-release.tar.zstd
+          retention-days: 1
         if: github.event_name == 'push' && github.repository == 'rust-lang/promote-release' && github.ref == 'refs/heads/master'
 
   deploy:


### PR DESCRIPTION
We only need the artifact for the Docker image to transfer data between jobs, and there is no point in downloading it separately. This sets the retention period to the minimum amount available, one day.