### PR TITLE
[disabled] Remove unused files from the release

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Error};
+use crate::Context;
+use anyhow::{Context as _, Error};
 use std::env::VarError;
 use std::str::FromStr;
 
@@ -9,6 +10,16 @@ pub(crate) enum Channel {
     Stable,
     Beta,
     Nightly,
+}
+
+impl Channel {
+    pub(crate) fn release_name(&self, ctx: &Context) -> String {
+        if *self == Channel::Stable {
+            ctx.current_version.clone().unwrap()
+        } else {
+            self.to_string()
+        }
+    }
 }
 
 impl FromStr for Channel {
@@ -70,6 +81,9 @@ pub(crate) struct Config {
     /// Whether to allow multiple releases on the same channel in the same day or not.
     pub(crate) allow_multiple_today: bool,
 
+    /// Whether to allow the work-in-progress pruning code for this release.
+    pub(crate) wip_prune_unused_files: bool,
+
     /// The compression level to use when recompressing tarballs with gzip.
     pub(crate) gzip_compression_level: u32,
     /// Custom sha of the commit to release, instead of the latest commit in the channel's branch.
@@ -105,6 +119,7 @@ impl Config {
             upload_addr: require_env("UPLOAD_ADDR")?,
             upload_bucket: require_env("UPLOAD_BUCKET")?,
             upload_dir: require_env("UPLOAD_DIR")?,
+            wip_prune_unused_files: bool_env("WIP_PRUNE_UNUSED_FILES")?,
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,12 @@ mod build_manifest;
 mod config;
 mod sign;
 
-use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
+use std::{collections::HashSet, env};
 
 use anyhow::Error;
 use build_manifest::BuildManifest;
@@ -21,6 +21,14 @@ use xz2::read::XzDecoder;
 use crate::config::{Channel, Config};
 
 const TARGET: &str = env!("TARGET");
+
+/// List of files that should not be pruned even if they're not referenced in the manifest.
+const AVOID_PRUNING_UNUSED_FILES: &[&str] = &[
+    // Source code tarballs, which are not distributed through rustup and thus are mistakenly
+    // marked as "unused" by build-manifest.
+    "rustc-{release}-src.tar.gz",
+    "rustc-{release}-src.tar.xz",
+];
 
 struct Context {
     work: PathBuf,
@@ -177,7 +185,14 @@ impl Context {
         let build_manifest = BuildManifest::new(self);
         if build_manifest.exists() {
             // Generate the channel manifest
-            build_manifest.run()?;
+            let execution = build_manifest.run()?;
+
+            if self.config.wip_prune_unused_files {
+                // Removes files that we are not shipping from the files we're about to upload.
+                if let Some(shipped_files) = &execution.shipped_files {
+                    self.prune_unused_files(&shipped_files)?;
+                }
+            }
 
             // Generate checksums and sign all the files we're about to ship.
             let signer = Signer::new(&self.config)?;
@@ -454,6 +469,28 @@ upload-addr = \"{}/{}\"
         for file in self.build_dir().join("build/dist/").read_dir()? {
             let file = file?;
             fs::copy(file.path(), self.dl_dir().join(file.file_name()))?;
+        }
+
+        Ok(())
+    }
+
+    fn prune_unused_files(&self, shipped_files: &HashSet<PathBuf>) -> Result<(), Error> {
+        let release = self.config.channel.release_name(self);
+        let allowed_files = AVOID_PRUNING_UNUSED_FILES
+            .iter()
+            .map(|pattern| pattern.replace("{release}", &release).into())
+            .collect::<HashSet<PathBuf>>();
+
+        for entry in std::fs::read_dir(self.dl_dir())? {
+            let entry = entry?;
+
+            if let Some(name) = entry.path().file_name() {
+                let name = Path::new(name);
+                if !allowed_files.contains(name) && !shipped_files.contains(name) {
+                    std::fs::remove_file(entry.path())?;
+                    println!("pruned unused file {}", name.display());
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Our releases currently include a bunch of "internal" files that are not useful for our downstream users but that happen to be stored in the artifacts bucket, such as CPU graphs, the `build-manifest` component, and similar. This PR implements purging them before shipping the release, by only retaining the files mentioned in the manifest, the files generated by `build-manifest` or the files matching a pattern explicitly allowed by `promote-release`.

This feature only works on rustc branches that include https://github.com/rust-lang/rust/pull/78196, and is currently **disabled**. To enable it the `PROMOTE_RELEASE_WIP_PRUNE_UNUSED_FILES` environment variable needs to be set. My current plan is to merge this, run a dev release with this feature enable, compare the result with the prod release, and then either fix the bugs or enable the feature by default (removing the flag).

r? @Mark-Simulacrum 