### PR TITLE
Add the PROMOTE_RELEASE_BYPASS_STARTUP_CHECKS variable

### DIFF
--- a/local/run.sh
+++ b/local/run.sh
@@ -132,7 +132,7 @@ export PROMOTE_RELEASE_UPLOAD_ADDR="http://localhost:9000/static"
 export PROMOTE_RELEASE_UPLOAD_BUCKET="static"
 export PROMOTE_RELEASE_UPLOAD_DIR="dist"
 # Environment variables used only by local releases
-export PROMOTE_RELEASE_ALLOW_MULTIPLE_TODAY="1"
+export PROMOTE_RELEASE_BYPASS_STARTUP_CHECKS="1"
 export PROMOTE_RELEASE_GZIP_COMPRESSION_LEVEL="1" # Faster recompressions
 export PROMOTE_RELEASE_S3_ENDPOINT_URL="http://minio:9000"
 export PROMOTE_RELEASE_SKIP_CLOUDFRONT_INVALIDATIONS="yes"

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,9 +77,13 @@ pub(crate) struct Config {
     pub(crate) upload_bucket: String,
     /// The S3 directory that release artifacts will be uploaded to.
     pub(crate) upload_dir: String,
-
-    /// Whether to allow multiple releases on the same channel in the same day or not.
-    pub(crate) allow_multiple_today: bool,
+    /// Whether to run the checks at startup that prevent a potentially unwanted release from
+    /// happening. If this is set to `true`, the following checks will be disabled:
+    ///
+    /// * Preventing multiple releases on the channel the same day.
+    /// * Preventing multiple releases on the channel of the same git commit.
+    /// * Preventing multiple releases on stable and beta of the same version number.
+    pub(crate) bypass_startup_checks: bool,
 
     /// Whether to allow the work-in-progress pruning code for this release.
     pub(crate) wip_prune_unused_files: bool,
@@ -102,7 +106,7 @@ pub(crate) struct Config {
 impl Config {
     pub(crate) fn from_env() -> Result<Self, Error> {
         Ok(Self {
-            allow_multiple_today: bool_env("ALLOW_MULTIPLE_TODAY")?,
+            bypass_startup_checks: bool_env("BYPASS_STARTUP_CHECKS")?,
             channel: require_env("CHANNEL")?,
             cloudfront_doc_id: require_env("CLOUDFRONT_DOC_ID")?,
             cloudfront_static_id: require_env("CLOUDFRONT_STATIC_ID")?,


### PR DESCRIPTION
This commit adds the `PROMOTE_RELEASE_BYPASS_STARTUP_CHECKS` enviornment variable, which replaces the `PROMOTE_RELEASE_ALLOW_MULTIPLE_TODAY` environment variable and adds more uses to it. Namely, the new enviornment variable will allow to skip all the startup checks that are meant to prevent an unwanted release from happening, not just the one that prevents multiple releases in the same day.

The use for this will mainly be to re-run dev stable releases. Instead of running a script to invalidate the current dev stable release and then starting the release process, it will be possible to just run:

```
./start-release.py dev stable --bypass-startup-checks
```

r? @Mark-Simulacrum 