### PR TITLE
Add WIP variable to test recompression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
  "git2",
  "hex",
  "hyper",
+ "num_cpus",
  "pgp",
  "rand 0.6.5",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ git2 = "0.13.11"
 tempfile = "3.1.0"
 hyper = "0.13.8"
 tokio = { version = "0.2.22", features = ["rt-threaded", "macros", "fs", "sync"] }
+num_cpus = "1.13.0"

--- a/src/build_manifest.rs
+++ b/src/build_manifest.rs
@@ -54,6 +54,7 @@ impl<'a> BuildManifest<'a> {
 
         println!("running build-manifest...");
         // build-manifest <input-dir> <output-dir> <date> <upload-addr> <channel>
+        let num_threads = self.builder.config.num_threads.to_string();
         let status = Command::new(bin.path())
             .arg(self.builder.dl_dir())
             .arg(self.builder.manifest_dir())
@@ -61,6 +62,7 @@ impl<'a> BuildManifest<'a> {
             .arg(upload_base)
             .arg(config.channel.to_string())
             .env("BUILD_MANIFEST_CHECKSUM_CACHE", &checksum_cache)
+            .env("BUILD_MANIFEST_NUM_THREADS", num_threads)
             .env("BUILD_MANIFEST_SHIPPED_FILES_PATH", &shipped_files_path)
             .status()
             .context("failed to execute build-manifest")?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,8 @@ pub(crate) struct Config {
 
     /// Whether to allow the work-in-progress pruning code for this release.
     pub(crate) wip_prune_unused_files: bool,
+    /// Whether to force the recompression of .gz files into .xz.
+    pub(crate) wip_recompress: bool,
 
     /// The compression level to use when recompressing tarballs with gzip.
     pub(crate) gzip_compression_level: u32,
@@ -127,6 +129,7 @@ impl Config {
             upload_bucket: require_env("UPLOAD_BUCKET")?,
             upload_dir: require_env("UPLOAD_DIR")?,
             wip_prune_unused_files: bool_env("WIP_PRUNE_UNUSED_FILES")?,
+            wip_recompress: bool_env("WIP_RECOMPRESS")?,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,8 @@ pub(crate) struct Config {
     pub(crate) gpg_key_file: String,
     /// Path of the file containing the password of the GPG secret key.
     pub(crate) gpg_password_file: String,
+    // Number of concurrent threads to start during the parallel segments of promote-release.
+    pub(crate) num_threads: usize,
     /// URL of the git repository containing the Rust source code.
     pub(crate) repository: String,
     /// Remote HTTP host artifacts will be uploaded to. Note that this is *not* the same as what's
@@ -115,6 +117,7 @@ impl Config {
             gpg_key_file: require_env("GPG_KEY_FILE")?,
             gpg_password_file: require_env("GPG_PASSWORD_FILE")?,
             gzip_compression_level: default_env("GZIP_COMPRESSION_LEVEL", 9)?,
+            num_threads: default_env("NUM_THREADS", num_cpus::get())?,
             override_commit: maybe_env("OVERRIDE_COMMIT")?,
             repository: default_env("REPOSITORY", "https://github.com/rust-lang/rust.git".into())?,
             s3_endpoint_url: maybe_env("S3_ENDPOINT_URL")?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,11 @@ impl Context {
     fn new(work: PathBuf, config: Config) -> Result<Self, Error> {
         let date = Utc::now().format("%Y-%m-%d").to_string();
 
+        // Configure the right amount of Rayon threads.
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(config.num_threads)
+            .build_global()?;
+
         Ok(Context {
             work,
             config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,9 +441,12 @@ upload-addr = \"{}/{}\"
                 // Generate *.gz from *.xz...
                 Some("xz") => {
                     let gz_path = path.with_extension("gz");
-                    if !gz_path.is_file() {
+                    if self.config.wip_recompress || !gz_path.is_file() {
                         to_recompress.push((path.to_path_buf(), gz_path));
                     }
+                }
+                Some("gz") if self.config.wip_recompress => {
+                    fs::remove_file(&path)?;
                 }
                 _ => {}
             }


### PR DESCRIPTION
This PR adds two environment variables to `promote-release`:

* `PROMOTE_RELEASE_NUM_THREADS`: while looking at the CPU graphs for our builds, I noticed the CPU was not maxed out during the parallel parts of the release process. The variable will allow to test different amounts of parallelism to see which one performs better.
* `PROMOTE_RELEASE_WIP_RECOMPRESS:` I want to see how much longer the release process will take to recompress all the `.xz` into `.gz`, so this PR adds a temporary environment variable I can set when testing a build.

r? @Mark-Simulacrum 