### PR TITLE
Make sure to use the minimal rustup profile during smoke tests

### DIFF
--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -59,7 +59,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # Install rustup while removing the pre-installed stable toolchain.
 RUN curl https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init >/tmp/rustup-init && \
     chmod +x /tmp/rustup-init && \
-    /tmp/rustup-init -y --no-modify-path --default-toolchain stable && \
+    /tmp/rustup-init -y --no-modify-path --profile minimal --default-toolchain stable && \
     /root/.cargo/bin/rustup toolchain remove stable
 ENV PATH=/root/.cargo/bin:$PATH
 

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -74,7 +74,13 @@ impl SmokeTester {
         };
 
         rustup(&["toolchain", "remove", &channel.to_string()])?;
-        rustup(&["toolchain", "install", &channel.to_string()])?;
+        rustup(&[
+            "toolchain",
+            "install",
+            &channel.to_string(),
+            "--profile",
+            "minimal",
+        ])?;
         cargo(&["init", "--bin", "."])?;
         cargo(&["run"])?;
 


### PR DESCRIPTION
If we don't use the minimal profile, releases will fail if an optional component in the default profile goes missing. This is what caused today's nightly outage.