### PR TITLE
Add support for private git repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         channel: [stable, beta, nightly]
+        mode: [standard, security]
 
     steps:
       - name: Clone the source code
@@ -47,7 +48,7 @@ jobs:
         run: docker-compose up -d
 
       - name: Run the local release process for channel ${{ matrix.channel }}
-        run: ./run.sh ${{ matrix.channel }}
+        run: ./run.sh ${{ matrix.channel }} ${{ matrix.mode }}
 
       - name: Validate the generated signatures
         run: docker-compose exec -T local /src/local/check-signature.sh ${{ matrix.channel }}

--- a/README.md
+++ b/README.md
@@ -31,11 +31,21 @@ environment variable while calling `rustup`:
 RUSTUP_DIST_SERVER="http://localhost:9000/static"
 ```
 
-You can also release a specific commit by providing its full hash as the second
+There are multiple modes you can test locally through the `./run.sh` script, by
+passing the mode name as the second argument. Each mode configures the local
+environment differently, to simulate different production scenarios. The modes
+currently available are:
+
+* `standard`: most of the Rust releases, including regular nightlies, betas or
+  stables.
+* `security`: private releases done to address security issues, fetching from
+  private artifacts buckets and private git repositories.
+
+You can also release a specific commit by providing its full hash as the third
 argument of `./run.sh`:
 
 ```
-./run.sh nightly 0000000000000000000000000000000000000000
+./run.sh nightly standard 0000000000000000000000000000000000000000
 ```
 
 ### Adding additional files to the local release

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     gnupg \
     jq \
     python3 \
-    socat
+    nginx
 
 # Install rustup while removing the pre-installed stable toolchain.
 RUN curl https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init >/tmp/rustup-init && \

--- a/local/github-simulated-auth-credentials.htpasswd
+++ b/local/github-simulated-auth-credentials.htpasswd
@@ -1,0 +1,1 @@
+username:{PLAIN}ghp_foobar

--- a/local/nginx.conf
+++ b/local/nginx.conf
@@ -1,0 +1,44 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+    worker_connections 768;
+}
+
+http {
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    gzip on;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    error_log /var/log/nginx/error.log;
+
+    # Proxies requests to minio, so that it's possible to access it via
+    # http://localhost:9000 in addition to http://minio:9000.
+    server {
+        listen 9000 default_server;
+        location / {
+            proxy_pass http://minio:9000;
+        }
+    }
+
+    # Simulate a git server with HTTP authentication. Behind the scenes this
+    # just proxies requests to GitHub.
+    server {
+        listen 8000 default_server;
+        location / {
+            proxy_pass https://github.com;
+            proxy_set_header Authorization "";
+
+            auth_basic "simulated GitHub authentication";
+            auth_basic_user_file /src/local/github-simulated-auth-credentials.htpasswd;
+        }
+    }
+}

--- a/local/run.sh
+++ b/local/run.sh
@@ -36,7 +36,8 @@ DOWNLOAD_STANDALONE=(
 )
 
 channel="$1"
-override_commit="$2"
+mode="$2"
+override_commit="$3"
 
 # Nightly is on the default branch
 if [[ "${channel}" = "nightly" ]]; then
@@ -116,6 +117,15 @@ export PROMOTE_RELEASE_SKIP_CLOUDFRONT_INVALIDATIONS="yes"
 if [[ "${override_commit}" != "" ]]; then
     export PROMOTE_RELEASE_OVERRIDE_COMMIT="${override_commit}"
 fi
+case "${mode}" in
+    standard)
+        export PROMOTE_RELEASE_REPOSITORY="https://github.com/rust-lang/rust.git"
+        ;;
+    security)
+        export PROMOTE_RELEASE_REPOSITORY="http://localhost:8000/rust-lang/rust.git"
+        export PROMOTE_RELEASE_REPOSITORY_AUTHENTICATION="username:ghp_foobar"
+        ;;
+esac
 
 echo "==> starting promote-release"
 /src/target/release/promote-release /persistent/release "${channel}"

--- a/local/setup.sh
+++ b/local/setup.sh
@@ -5,9 +5,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-MINIO_HOST="minio"
-MINIO_PORT="9000"
-MINIO_URL="http://${MINIO_HOST}:${MINIO_PORT}"
+MINIO_URL="http://minio:9000"
 MINIO_ACCESS_KEY="access_key"
 MINIO_SECRET_KEY="secret_key"
 
@@ -23,8 +21,8 @@ while ! curl --silent --fail "${MINIO_URL}/minio/health/cluster"; do
 done
 echo "minio is now available"
 
-echo "starting a proxy for minio"
-socat "tcp-listen:${MINIO_PORT},reuseaddr,fork" "tcp:${MINIO_HOST}:${MINIO_PORT}" &
+echo "starting nginx to proxy minio and github"
+nginx -c /src/local/nginx.conf
 
 # Configure the minio client to talk to the right instance.
 echo "configuring cli access to minio"

--- a/run.sh
+++ b/run.sh
@@ -6,11 +6,16 @@ set -euo pipefail
 IFS=$'\n\t'
 
 if [[ "$#" -lt 1 ]] || [[ "$#" -gt 2 ]]; then
-    echo "Usage: $0 <channel> [commit]"
+    echo "Usage: $0 <channel> [mode] [commit]"
+    echo
+    echo "Mode can be:"
+    echo " - standard (default)"
+    echo " - security"
     exit 1
 fi
 channel="$1"
-override_commit="${2-}"
+mode="${2-standard}"
+override_commit="${3-}"
 
 container_id="$(docker-compose ps -q local)"
 if [[ "${container_id}" == "" ]]; then
@@ -31,4 +36,4 @@ fi
 cargo build --release
 
 # Run the command inside the docker environment.
-docker-compose exec -T local /src/local/run.sh "${channel}" "${override_commit}"
+docker-compose exec -T local /src/local/run.sh "${channel}" "${mode}" "${override_commit}"

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,7 +139,7 @@ pub(crate) struct RepositoryCredentials {
 
 impl RepositoryCredentials {
     pub(crate) fn as_git2_credentials(&self) -> Result<Cred, git2::Error> {
-        Ok(Cred::userpass_plaintext(&self.username, &self.password)?)
+        Cred::userpass_plaintext(&self.username, &self.password)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ impl Context {
                 .repository_authentication
                 .as_ref()
                 .map(|c| c.as_git2_credentials())
-                .unwrap_or_else(|| git2::Cred::default())
+                .unwrap_or_else(git2::Cred::default)
         });
 
         println!(
@@ -169,7 +169,7 @@ impl Context {
         // The bypass_startup_checks condition is after the function call since we need that
         // function to run even if we wan to discard its output (it fetches and stores the current
         // version we're about to release).
-        if self.current_version_same(&previous_version)? && !self.config.bypass_startup_checks {
+        if self.current_version_same(previous_version)? && !self.config.bypass_startup_checks {
             println!("version hasn't changed, skipping");
             println!("set PROMOTE_RELEASE_BYPASS_STARTUP_CHECKS=1 to bypass the check");
             return Ok(());
@@ -201,7 +201,7 @@ impl Context {
 
         // Removes files that we are not shipping from the files we're about to upload.
         if let Some(shipped_files) = &execution.shipped_files {
-            self.prune_unused_files(&shipped_files)?;
+            self.prune_unused_files(shipped_files)?;
         }
 
         // Sign both the downloaded artifacts and all the generated manifests. The signatures
@@ -548,7 +548,7 @@ impl Context {
                 .arg("--only-show-errors")
                 .arg(format!("{}/", docs.display()))
                 .arg(&dst))?;
-            self.invalidate_docs(&version)?;
+            self.invalidate_docs(version)?;
         }
 
         Ok(())
@@ -672,7 +672,7 @@ impl Context {
     fn download_file(&mut self, url: &str) -> Result<Option<String>, Error> {
         self.handle.reset();
         self.handle.get(true)?;
-        self.handle.url(&url)?;
+        self.handle.url(url)?;
         let mut result = Vec::new();
         {
             let mut t = self.handle.transfer();

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -139,6 +139,7 @@ impl Signer {
 }
 
 fn should_exclude_path(path: &Path) -> bool {
+    #[allow(clippy::match_like_matches_macro)]
     match path.extension().and_then(|ext| ext.to_str()) {
         Some("asc") => true,    // GPG signatures
         Some("sha256") => true, // SHA256 checksums


### PR DESCRIPTION
This PR adds support for authenticating to git repositories during the release process by setting the environment variable `PROMOTE_RELEASE_REPOSITORY_AUTHENTICATION=user:pass`.

r? @Mark-Simulacrum 