### PR TITLE
Switch dist artifact uploads to intelligent tiering

### DIFF
--- a/local/run.sh
+++ b/local/run.sh
@@ -29,6 +29,13 @@ DOWNLOAD_COMPONENTS=(
 DOWNLOAD_COMPONENT_TARGETS=(
     "x86_64-unknown-linux-gnu"
 )
+# These components are necessary for build-manifest to run, as they're fallback
+# targets from a host of tier-2 triples. See build-manifest/src/main.rs
+# DOCS_FALLBACK.
+DOWNLOAD_DOCS_TARGETS=(
+    "x86_64-apple-darwin"
+    "aarch64-unknown-linux-gnu"
+)
 # Files to download that are not rustup components. No mangling is done on the
 # file name, so include its full path.
 DOWNLOAD_STANDALONE=(
@@ -86,6 +93,9 @@ for target in "${DOWNLOAD_COMPONENT_TARGETS[@]}"; do
     for component in "${DOWNLOAD_COMPONENTS[@]}"; do
         download "${component}-${release}-${target}.tar.xz"
     done
+done
+for target in "${DOWNLOAD_DOCS_TARGETS[@]}"; do
+    download "rust-docs-${release}-${target}.tar.xz"
 done
 for file in "${DOWNLOAD_STANDALONE[@]}"; do
     download "${file}"

--- a/local/run.sh
+++ b/local/run.sh
@@ -106,6 +106,7 @@ export PROMOTE_RELEASE_GPG_KEY_FILE="/persistent/gpg-key"
 export PROMOTE_RELEASE_GPG_PASSWORD_FILE="/persistent/gpg-password"
 export PROMOTE_RELEASE_UPLOAD_ADDR="http://localhost:9000/static"
 export PROMOTE_RELEASE_UPLOAD_BUCKET="static"
+export PROMOTE_RELEASE_UPLOAD_STORAGE_CLASS="STANDARD"
 export PROMOTE_RELEASE_UPLOAD_DIR="dist"
 # Environment variables used only by local releases
 export PROMOTE_RELEASE_BYPASS_STARTUP_CHECKS="1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,9 @@ pub(crate) struct Config {
     pub(crate) upload_addr: String,
     /// The S3 bucket that release artifacts will be uploaded to.
     pub(crate) upload_bucket: String,
+    /// The storage class artifacts are created in. Primarily used for testing
+    /// (we default to INTELLIGENT_TIERING if not set).
+    pub(crate) storage_class: String,
     /// The S3 directory that release artifacts will be uploaded to.
     pub(crate) upload_dir: String,
     /// Whether to run the checks at startup that prevent a potentially unwanted release from
@@ -121,6 +124,7 @@ impl Config {
             skip_cloudfront_invalidations: bool_env("SKIP_CLOUDFRONT_INVALIDATIONS")?,
             upload_addr: require_env("UPLOAD_ADDR")?,
             upload_bucket: require_env("UPLOAD_BUCKET")?,
+            storage_class: default_env("UPLOAD_STORAGE_CLASS", "INTELLIGENT_TIERING".into())?,
             upload_dir: require_env("UPLOAD_DIR")?,
             wip_recompress: bool_env("WIP_RECOMPRESS")?,
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,6 +441,8 @@ impl Context {
             .arg("REPLACE")
             .arg("--cache-control")
             .arg("public")
+            .arg("--storage-class")
+            .arg(&self.config.storage_class)
             .arg(format!("{}/", self.dl_dir().display()))
             .arg(&dst))
     }
@@ -519,6 +521,8 @@ impl Context {
         run(self
             .aws_s3()
             .arg("sync")
+            .arg("--storage-class")
+            .arg(&self.config.storage_class)
             .arg("--delete")
             .arg("--only-show-errors")
             .arg(format!("{}/", docs.display()))
@@ -531,6 +535,8 @@ impl Context {
             run(self
                 .aws_s3()
                 .arg("sync")
+                .arg("--storage-class")
+                .arg(&self.config.storage_class)
                 .arg("--delete")
                 .arg("--only-show-errors")
                 .arg(format!("{}/", docs.display()))
@@ -561,6 +567,8 @@ impl Context {
             .arg("cp")
             .arg("--recursive")
             .arg("--only-show-errors")
+            .arg("--storage-class")
+            .arg(&self.config.storage_class)
             .arg(format!("{}/", self.dl_dir().display()))
             .arg(&dst))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ impl Context {
         // The bypass_startup_checks condition is after the function call since we need that
         // function to run even if we wan to discard its output (it fetches and stores the current
         // version we're about to release).
-        if self.current_version_same(&previous_version)? && !self.config.bypass_startup_checks {
+        if self.current_version_same(previous_version)? && !self.config.bypass_startup_checks {
             println!("version hasn't changed, skipping");
             println!("set PROMOTE_RELEASE_BYPASS_STARTUP_CHECKS=1 to bypass the check");
             return Ok(());
@@ -188,7 +188,7 @@ impl Context {
 
         // Removes files that we are not shipping from the files we're about to upload.
         if let Some(shipped_files) = &execution.shipped_files {
-            self.prune_unused_files(&shipped_files)?;
+            self.prune_unused_files(shipped_files)?;
         }
 
         // Sign both the downloaded artifacts and all the generated manifests. The signatures
@@ -541,7 +541,7 @@ impl Context {
                 .arg("--only-show-errors")
                 .arg(format!("{}/", docs.display()))
                 .arg(&dst))?;
-            self.invalidate_docs(&version)?;
+            self.invalidate_docs(version)?;
         }
 
         Ok(())
@@ -667,7 +667,7 @@ impl Context {
     fn download_file(&mut self, url: &str) -> Result<Option<String>, Error> {
         self.handle.reset();
         self.handle.get(true)?;
-        self.handle.url(&url)?;
+        self.handle.url(url)?;
         let mut result = Vec::new();
         {
             let mut t = self.handle.transfer();

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -144,6 +144,7 @@ impl Signer {
     }
 }
 
+#[allow(clippy::match_like_matches_macro)]
 fn should_exclude_path(path: &Path) -> bool {
     match path.extension().and_then(|ext| ext.to_str()) {
         Some("asc") => true,    // GPG signatures


### PR DESCRIPTION
This should automatically put artifacts in cold storage as they decrease in use
over time. We do this for all artifacts, including documentation. Many of the
files uploaded for documentation aren't going to actually be eligible for colder
storage (there's a minimum size of 128KB) but in that case they'll just be
stored in standard storage as before and not monitored, which works well for us.

r? @pietroalbini 