### PR TITLE
Post internals + blog PR after publishing dev-static releases

### DIFF
--- a/src/curl_helper.rs
+++ b/src/curl_helper.rs
@@ -1,0 +1,68 @@
+use anyhow::Context;
+use curl::easy::Easy;
+
+pub trait BodyExt {
+    fn with_body<S>(&mut self, body: S) -> Request<'_, S>;
+    fn without_body(&mut self) -> Request<'_, ()>;
+}
+
+impl BodyExt for Easy {
+    fn with_body<S>(&mut self, body: S) -> Request<'_, S> {
+        Request {
+            body: Some(body),
+            client: self,
+        }
+    }
+    fn without_body(&mut self) -> Request<'_, ()> {
+        Request {
+            body: None,
+            client: self,
+        }
+    }
+}
+
+pub struct Request<'a, S> {
+    body: Option<S>,
+    client: &'a mut Easy,
+}
+
+impl<S: serde::Serialize> Request<'_, S> {
+    pub fn send_with_response<T: serde::de::DeserializeOwned>(self) -> anyhow::Result<T> {
+        use std::io::Read;
+        let mut response = Vec::new();
+        let body = self.body.map(|body| serde_json::to_vec(&body).unwrap());
+        {
+            let mut transfer = self.client.transfer();
+            // The unwrap in the read_function is basically guaranteed to not
+            // happen: reading into a slice can't fail. We can't use `?` since the
+            // return type inside transfer isn't compatible with io::Error.
+            if let Some(mut body) = body.as_deref() {
+                transfer.read_function(move |dest| Ok(body.read(dest).unwrap()))?;
+            }
+            transfer.write_function(|new_data| {
+                response.extend_from_slice(new_data);
+                Ok(new_data.len())
+            })?;
+            transfer.perform()?;
+        }
+        serde_json::from_slice(&response)
+            .with_context(|| format!("{}", String::from_utf8_lossy(&response)))
+    }
+
+    pub fn send(self) -> anyhow::Result<()> {
+        use std::io::Read;
+        let body = self.body.map(|body| serde_json::to_vec(&body).unwrap());
+        {
+            let mut transfer = self.client.transfer();
+            // The unwrap in the read_function is basically guaranteed to not
+            // happen: reading into a slice can't fail. We can't use `?` since the
+            // return type inside transfer isn't compatible with io::Error.
+            if let Some(mut body) = body.as_deref() {
+                transfer.read_function(move |dest| Ok(body.read(dest).unwrap()))?;
+            }
+            transfer.perform()?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/discourse.rs
+++ b/src/discourse.rs
@@ -1,0 +1,69 @@
+use crate::curl_helper::BodyExt;
+use curl::easy::Easy;
+
+pub struct Discourse {
+    root: String,
+    api_key: String,
+    api_username: String,
+    client: Easy,
+}
+
+impl Discourse {
+    pub fn new(root: String, api_username: String, api_key: String) -> Discourse {
+        Discourse {
+            root,
+            api_key,
+            api_username,
+            client: Easy::new(),
+        }
+    }
+
+    fn start_new_request(&mut self) -> anyhow::Result<()> {
+        self.client.reset();
+        self.client.useragent("rust-lang/promote-release")?;
+        let mut headers = curl::easy::List::new();
+        headers.append(&format!("Api-Key: {}", self.api_key))?;
+        headers.append(&format!("Api-Username: {}", self.api_username))?;
+        headers.append("Content-Type: application/json")?;
+        self.client.http_headers(headers)?;
+        Ok(())
+    }
+
+    /// Returns a URL to the topic
+    pub fn create_topic(
+        &mut self,
+        category: u32,
+        title: &str,
+        body: &str,
+    ) -> anyhow::Result<String> {
+        #[derive(serde::Serialize)]
+        struct Request<'a> {
+            title: &'a str,
+            #[serde(rename = "raw")]
+            body: &'a str,
+            category: u32,
+            archetype: &'a str,
+        }
+        #[derive(serde::Deserialize)]
+        struct Response {
+            topic_id: u32,
+            topic_slug: String,
+        }
+        self.start_new_request()?;
+        self.client.post(true)?;
+        self.client.url(&format!("{}/posts.json", self.root))?;
+        let resp = self
+            .client
+            .with_body(Request {
+                title,
+                body,
+                category,
+                archetype: "regular",
+            })
+            .send_with_response::<Response>()?;
+        Ok(format!(
+            "{}/t/{}/{}",
+            self.root, resp.topic_slug, resp.topic_id
+        ))
+    }
+}


### PR DESCRIPTION
Tested locally -- see https://internals.rust-lang.org/t/rust-1-62-0-pre-release-testing-v2/16983 (may need admin credentials) and https://github.com/Mark-Simulacrum/blog.rust-lang.org/pull/8 for the sample PRs opened by this.

I think the PR being opened vs. directly pushing makes sense, but we could consider altering that in the future, once this is proven to work.