### PR TITLE
Support branch promotion

### DIFF
--- a/src/branching.rs
+++ b/src/branching.rs
@@ -1,0 +1,72 @@
+use crate::Context;
+
+impl Context {
+    /// Let $stable, $beta, $master be the tips of each branch (when starting).
+    ///
+    /// * Set stable to $beta.
+    /// * Set beta to $master (ish, look for the version bump).
+    /// * Create a rust-lang/cargo branch for the appropriate beta commit.
+    /// * Post a PR against the newly created beta branch bump src/ci/channel to `beta`.
+    pub fn do_branching(&mut self) -> anyhow::Result<()> {
+        let mut github = if let Some(github) = self.config.github() {
+            github
+        } else {
+            eprintln!("Skipping branching -- github credentials not configured");
+            return Ok(());
+        };
+        let mut token = github.token("rust-lang/rust")?;
+        let prebump_sha = token.last_commit_for_file("src/version")?;
+        let beta_sha = token.get_ref("heads/beta")?;
+
+        let stable_version = token.read_file(Some("stable"), "src/version")?;
+        let beta_version = token.read_file(Some("beta"), "src/version")?;
+        let future_beta_version = token.read_file(Some(&prebump_sha), "src/version")?;
+
+        // Check that we've not already promoted. Rather than trying to assert
+        // +1 version numbers, we instead have a simpler check that all the
+        // versions are unique -- before promotion we should have:
+        //
+        // * stable @ 1.61.0
+        // * beta @ 1.62.0
+        // * prebump @ 1.63.0
+        //
+        // and after promotion we will have (if we were to read the files again):
+        //
+        // * stable @ 1.62.0
+        // * beta @ 1.63.0
+        // * prebump @ 1.63.0
+        //
+        // In this state, if we try to promote again, we want to bail out. The
+        // stable == beta check isn't as useful, but still nice to have.
+        if stable_version.content()? == beta_version.content()? {
+            anyhow::bail!(
+                "Stable and beta have the same version: {}; refusing to promote branches.",
+                stable_version.content()?.trim()
+            );
+        }
+        if beta_version.content()? == future_beta_version.content()? {
+            anyhow::bail!(
+                "Beta and pre-bump master ({}) have the same version: {}; refusing to promote branches.",
+                prebump_sha,
+                beta_version.content()?.trim()
+            );
+        }
+
+        // No need to disable branch protection, as the promote-release app is
+        // specifically authorized to force-push to these branches.
+        token.update_ref("heads/stable", &beta_sha, true)?;
+        token.update_ref("heads/beta", &prebump_sha, true)?;
+
+        let cargo_sha = token
+            .read_file(Some(&prebump_sha), "src/tools/cargo")?
+            .submodule_sha()
+            .to_owned();
+
+        let mut github = self.config.github().unwrap();
+        let mut token = github.token("rust-lang/cargo")?;
+        let new_beta = future_beta_version.content()?.trim().to_owned();
+        token.create_ref(&dbg!(format!("heads/rust-{}", new_beta)), &cargo_sha)?;
+
+        Ok(())
+    }
+}

--- a/src/curl_helper.rs
+++ b/src/curl_helper.rs
@@ -1,0 +1,68 @@
+use anyhow::Context;
+use curl::easy::Easy;
+
+pub trait BodyExt {
+    fn with_body<S>(&mut self, body: S) -> Request<'_, S>;
+    fn without_body(&mut self) -> Request<'_, ()>;
+}
+
+impl BodyExt for Easy {
+    fn with_body<S>(&mut self, body: S) -> Request<'_, S> {
+        Request {
+            body: Some(body),
+            client: self,
+        }
+    }
+    fn without_body(&mut self) -> Request<'_, ()> {
+        Request {
+            body: None,
+            client: self,
+        }
+    }
+}
+
+pub struct Request<'a, S> {
+    body: Option<S>,
+    client: &'a mut Easy,
+}
+
+impl<S: serde::Serialize> Request<'_, S> {
+    pub fn send_with_response<T: serde::de::DeserializeOwned>(self) -> anyhow::Result<T> {
+        use std::io::Read;
+        let mut response = Vec::new();
+        let body = self.body.map(|body| serde_json::to_vec(&body).unwrap());
+        {
+            let mut transfer = self.client.transfer();
+            // The unwrap in the read_function is basically guaranteed to not
+            // happen: reading into a slice can't fail. We can't use `?` since the
+            // return type inside transfer isn't compatible with io::Error.
+            if let Some(mut body) = body.as_deref() {
+                transfer.read_function(move |dest| Ok(body.read(dest).unwrap()))?;
+            }
+            transfer.write_function(|new_data| {
+                response.extend_from_slice(new_data);
+                Ok(new_data.len())
+            })?;
+            transfer.perform()?;
+        }
+        serde_json::from_slice(&response)
+            .with_context(|| format!("{}", String::from_utf8_lossy(&response)))
+    }
+
+    pub fn send(self) -> anyhow::Result<()> {
+        use std::io::Read;
+        let body = self.body.map(|body| serde_json::to_vec(&body).unwrap());
+        {
+            let mut transfer = self.client.transfer();
+            // The unwrap in the read_function is basically guaranteed to not
+            // happen: reading into a slice can't fail. We can't use `?` since the
+            // return type inside transfer isn't compatible with io::Error.
+            if let Some(mut body) = body.as_deref() {
+                transfer.read_function(move |dest| Ok(body.read(dest).unwrap()))?;
+            }
+            transfer.perform()?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/discourse.rs
+++ b/src/discourse.rs
@@ -1,0 +1,69 @@
+use crate::curl_helper::BodyExt;
+use curl::easy::Easy;
+
+pub struct Discourse {
+    root: String,
+    api_key: String,
+    api_username: String,
+    client: Easy,
+}
+
+impl Discourse {
+    pub fn new(root: String, api_username: String, api_key: String) -> Discourse {
+        Discourse {
+            root,
+            api_key,
+            api_username,
+            client: Easy::new(),
+        }
+    }
+
+    fn start_new_request(&mut self) -> anyhow::Result<()> {
+        self.client.reset();
+        self.client.useragent("rust-lang/promote-release")?;
+        let mut headers = curl::easy::List::new();
+        headers.append(&format!("Api-Key: {}", self.api_key))?;
+        headers.append(&format!("Api-Username: {}", self.api_username))?;
+        headers.append("Content-Type: application/json")?;
+        self.client.http_headers(headers)?;
+        Ok(())
+    }
+
+    /// Returns a URL to the topic
+    pub fn create_topic(
+        &mut self,
+        category: u32,
+        title: &str,
+        body: &str,
+    ) -> anyhow::Result<String> {
+        #[derive(serde::Serialize)]
+        struct Request<'a> {
+            title: &'a str,
+            #[serde(rename = "raw")]
+            body: &'a str,
+            category: u32,
+            archetype: &'a str,
+        }
+        #[derive(serde::Deserialize)]
+        struct Response {
+            topic_id: u32,
+            topic_slug: String,
+        }
+        self.start_new_request()?;
+        self.client.post(true)?;
+        self.client.url(&format!("{}/posts.json", self.root))?;
+        let resp = self
+            .client
+            .with_body(Request {
+                title,
+                body,
+                category,
+                archetype: "regular",
+            })
+            .send_with_response::<Response>()?;
+        Ok(format!(
+            "{}/t/{}/{}",
+            self.root, resp.topic_slug, resp.topic_id
+        ))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::rc_buffer)]
 
+mod branching;
 mod build_manifest;
 mod config;
 mod curl_helper;
@@ -71,8 +72,10 @@ impl Context {
 
     fn run(&mut self) -> Result<(), Error> {
         let _lock = self.lock()?;
-        self.do_release()?;
-
+        match self.config.action {
+            config::Action::PromoteRelease => self.do_release()?,
+            config::Action::PromoteBranches => self.do_branching()?,
+        }
         Ok(())
     }
 


### PR DESCRIPTION
This bumps branches on rust-lang/rust and creates the cargo branch at the
appropriate commit; the only missing component is the actual PR that will bump
the channel (src/ci/channel) to stable and cherry pick a fresh copy of the
release notes. I think it makes sense for now to leave that step to human hands:
it's pretty manual (need to track down the release notes, which might or might
not have merged already; need to check for last minute beta backports...). So
humans likely are involved anyway, at which point it's not really a huge win for
us to automate opening a PR or creating a temporary branch.

This automation already avoids the annoying bits and the bits that require
privileges (e.g., force pushing branches).

Based on #45