### PR TITLE
Fix src/version parent finding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
         run: cargo clippy -- -Dwarnings
 
       - name: Ensure tests are passing
-        run: cargo test
+        run: cargo test -- --nocapture
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   local:
     name: Local release


### PR DESCRIPTION
GitHub doesn't return merge commits when searching by changed file path,
so our previous logic was finding the human-authored commit rather than
the bors merge commit. New logic looks for the first bors commit which
has the last human commit changing src/version, which should hopefully
work here.

Fixes #49