### PR TITLE
Directly push dev-static announcement

### DIFF
--- a/src/build_manifest.rs
+++ b/src/build_manifest.rs
@@ -42,9 +42,9 @@ impl<'a> BuildManifest<'a> {
 
         // Ensure the manifest dir exists but is empty.
         if dest.is_dir() {
-            std::fs::remove_dir_all(&dest)?;
+            std::fs::remove_dir_all(dest)?;
         }
-        std::fs::create_dir_all(&dest)?;
+        std::fs::create_dir_all(dest)?;
 
         // Ensure the shipped files path does not exists
         if self.shipped_files_path.is_file() {

--- a/src/github.rs
+++ b/src/github.rs
@@ -315,6 +315,8 @@ impl RepositoryClient<'_> {
         Ok(())
     }
 
+    // This isn't currently used but might be again in the future, for now just leave it in place.
+    #[allow(unused)]
     pub(crate) fn create_pr(
         &mut self,
         base: &str,

--- a/src/github.rs
+++ b/src/github.rs
@@ -48,7 +48,7 @@ impl Github {
                 &sha2::Sha256::new()
                     .chain_update(format!(
                         "{}.{}",
-                        base64::encode_config(&header, encoding),
+                        base64::encode_config(header, encoding),
                         base64::encode_config(&payload, encoding),
                     ))
                     .finalize(),
@@ -56,9 +56,9 @@ impl Github {
             .unwrap();
         format!(
             "{}.{}.{}",
-            base64::encode_config(&header, encoding),
+            base64::encode_config(header, encoding),
             base64::encode_config(&payload, encoding),
-            base64::encode_config(&signature, encoding),
+            base64::encode_config(signature, encoding),
         )
     }
 
@@ -309,7 +309,7 @@ impl RepositoryClient<'_> {
             .with_body(Request {
                 branch,
                 message: "Creating file via promote-release automation",
-                content: &base64::encode(&content),
+                content: &base64::encode(content),
             })
             .send()?;
         Ok(())
@@ -434,7 +434,7 @@ impl GitFile {
     pub(crate) fn content(&self) -> anyhow::Result<String> {
         if let GitFile::File { encoding, content } = self {
             assert_eq!(encoding, "base64");
-            Ok(String::from_utf8(base64::decode(&content.trim())?)?)
+            Ok(String::from_utf8(base64::decode(content.trim())?)?)
         } else {
             panic!("content() on {:?}", self);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,7 @@ impl Context {
         smoke_test.test(&self.config.channel)?;
 
         // Merge the generated manifests with the downloaded artifacts.
-        for entry in std::fs::read_dir(&self.real_manifest_dir())? {
+        for entry in std::fs::read_dir(self.real_manifest_dir())? {
             let entry = entry?;
             if entry.file_type()?.is_file() {
                 std::fs::rename(entry.path(), self.dl_dir().join(entry.file_name()))?;
@@ -228,7 +228,7 @@ impl Context {
 
         // Clean up after ourselves to avoid leaving gigabytes of artifacts
         // around.
-        let _ = fs::remove_dir_all(&self.dl_dir());
+        let _ = fs::remove_dir_all(self.dl_dir());
 
         // This opens a PR and starts an internals thread announcing a
         // stable dev-release (we distinguish dev by the presence of metadata
@@ -259,7 +259,7 @@ impl Context {
             }
             println!("looking inside {} for a version", filename);
 
-            let file = File::open(&e.path())?;
+            let file = File::open(e.path())?;
             let reader = flate2::read::GzDecoder::new(file);
             let mut archive = tar::Archive::new(reader);
 
@@ -738,7 +738,7 @@ impl Context {
 
         let mut token = github.token(repository_for_blog)?;
         token.create_file(
-            &BLOG_PRIMARY_BRANCH,
+            BLOG_PRIMARY_BRANCH,
             &format!(
                 "posts/inside-rust/{}-{}-prerelease.md",
                 chrono::Utc::today().format("%Y-%m-%d"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -736,15 +736,9 @@ impl Context {
             return Ok(());
         };
 
-        // Create a new branch so that we don't need to worry about the file
-        // already existing. In practice this *could* collide, but after merging
-        // a PR branches should get deleted, so it's very unlikely.
-        let name = format!("automation-{:x}", rand::random::<u32>());
         let mut token = github.token(repository_for_blog)?;
-        let master_sha = token.get_ref(&format!("heads/{BLOG_PRIMARY_BRANCH}"))?;
-        token.create_ref(&format!("refs/heads/{name}"), &master_sha)?;
         token.create_file(
-            &name,
+            &BLOG_PRIMARY_BRANCH,
             &format!(
                 "posts/inside-rust/{}-{}-prerelease.md",
                 chrono::Utc::today().format("%Y-%m-%d"),
@@ -752,7 +746,6 @@ impl Context {
             ),
             &blog_contents,
         )?;
-        token.create_pr(BLOG_PRIMARY_BRANCH, &name, "Pre-release announcement", "")?;
 
         Ok(())
     }


### PR DESCRIPTION
The blog repository has been configured to allow direct pushes (bypassing the regular branch protection), though not force pushes, by the promote release bot.

This hasn't been tested yet -- I figure the easiest thing is to do so as part of a release. Worst case we manually produce and merge the file, which isn't that hard.