### PR TITLE
Suppress zero padding in "scheduled for" date

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -248,7 +248,7 @@ impl Config {
             release.replace('.', ""),
             scheduled_release_date.format("%Y-%m-%d"),
         );
-        let human_date = scheduled_release_date.format("%B %d");
+        let human_date = scheduled_release_date.format("%B %-d");
         let internals = internals_url
             .map(|url| format!("You can leave feedback on the [internals thread]({url})."))
             .unwrap_or_default();


### PR DESCRIPTION
I noticed this in https://github.com/rust-lang/blog.rust-lang.org/pull/1087.

You can find the documentation of `%-?` in https://docs.rs/chrono/0.4.23/chrono/format/strftime/index.html#specifiers.

```rust
fn main() {
    let scheduled_release_date = chrono::NaiveDate::from_ymd_opt(2023, 3, 9).unwrap();
    println!("{}", scheduled_release_date.format("%B %d"));
    println!("{}", scheduled_release_date.format("%B %-d"));
}
```

```console
March 09
March 9
```