### PR TITLE
Bump versions for action dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Ensure Rust Stable is up to date
         run: rustup self update && rustup update stable
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Clone the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Ensure Rust Stable is up to date
         run: rustup self update && rustup update stable
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Clone the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build the Docker image
         run: docker build -t promote-release -f prod/Dockerfile .
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Download the Docker image previously built
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-image
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::890664054962:role/ci--rust-lang-promote-release
           aws-region: us-west-1


### PR DESCRIPTION
I think these are mostly no-op bumps, just using a newer NodeJS (16 vs 12) in their own dependencies. Not quite sure why that merits a major version, but seems like we should be on latest regardless.