### PR TITLE
Invalidate release distribution on Fastly

### DIFF
--- a/src/fastly.rs
+++ b/src/fastly.rs
@@ -1,0 +1,40 @@
+use anyhow::Error;
+use curl::easy::Easy;
+
+pub struct Fastly {
+    api_token: String,
+    domain: String,
+    client: Easy,
+}
+
+impl Fastly {
+    pub fn new(api_token: String, domain: String) -> Self {
+        Self {
+            api_token,
+            domain,
+            client: Easy::new(),
+        }
+    }
+
+    pub fn purge(&mut self, path: &str) -> Result<(), Error> {
+        self.start_new_request()?;
+
+        self.client.post(true)?;
+        self.client.url(&format!(
+            "https://api.fastly.com/purge/{}/{}",
+            self.domain, path
+        ))?;
+
+        self.client.perform().map_err(|error| error.into())
+    }
+
+    fn start_new_request(&mut self) -> anyhow::Result<()> {
+        self.client.reset();
+        self.client.useragent("rust-lang/promote-release")?;
+        let mut headers = curl::easy::List::new();
+        headers.append(&format!("Fastly-Key: {}", self.api_token))?;
+        headers.append("Content-Type: application/json")?;
+        self.client.http_headers(headers)?;
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod build_manifest;
 mod config;
 mod curl_helper;
 mod discourse;
+mod fastly;
 mod github;
 mod recompress;
 mod sign;
@@ -18,6 +19,7 @@ use std::time::Duration;
 use std::{collections::HashSet, env};
 
 use crate::build_manifest::BuildManifest;
+use crate::config::{Channel, Config};
 use crate::sign::Signer;
 use crate::smoke_test::SmokeTester;
 use anyhow::Error;
@@ -25,8 +27,6 @@ use chrono::Utc;
 use curl::easy::Easy;
 use fs2::FileExt;
 use github::{CreateTag, Github};
-
-use crate::config::{Channel, Config};
 
 const TARGET: &str = env!("TARGET");
 
@@ -557,7 +557,12 @@ impl Context {
     }
 
     fn invalidate_releases(&self) -> Result<(), Error> {
-        self.invalidate_cloudfront(&self.config.cloudfront_static_id, &["/dist/*".into()])
+        let paths = ["/dist/*".into()];
+
+        self.invalidate_cloudfront(&self.config.cloudfront_static_id, &paths)?;
+        self.invalidate_fastly(&paths)?;
+
+        Ok(())
     }
 
     fn invalidate_cloudfront(&self, distribution_id: &str, paths: &[String]) -> Result<(), Error> {
@@ -588,6 +593,32 @@ impl Context {
             .arg(format!("file://{}", dst.display()))
             .arg("--distribution-id")
             .arg(distribution_id))?;
+
+        Ok(())
+    }
+
+    fn invalidate_fastly(&self, paths: &[String]) -> Result<(), Error> {
+        // Fastly invalidations are opt-in while we test the integration
+        // Set PROMOTE_RELEASE_INVALIDATE_FASTLY=1 to enable them
+        if !self.config.invalidate_fastly {
+            return Ok(());
+        }
+
+        let mut fastly = match self.config.fastly() {
+            Some(fastly) => fastly,
+            None => {
+                println!();
+                println!("WARNING! Skipped Fastly invalidation of: {:?}", paths);
+                println!("Set PROMOTE_RELEASE_FASTLY_API_TOKEN and PROMOTE_RELEASE_FASTLY_STATIC_DOMAIN if you want to invalidate Fastly");
+                println!();
+                return Ok(());
+            }
+        };
+
+        for path in paths {
+            let path = path.replace('*', "");
+            fastly.purge(&path)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
We are working on serving Rust releases through Fastly as well as CloudFront. The logic to invalidate cached released has therefore been slightly reworked to handle both CDNs.

First, new environment variables have been added to configure the Fastly integration. An API token is required as is the domain name that should get invalidated.

Second, a temporary environment variable has been added that enables the integration. This enables us to test the integration in the dev environment without requiring any changes to the production environment.