### PR TITLE
Automate Cargo tagging

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -151,6 +151,14 @@ pub(crate) struct Config {
     /// Should be a org/repo code, e.g., rust-lang/rust.
     pub(crate) rustc_tag_repository: Option<String>,
 
+    /// Where to tag stable cargo releases.
+    ///
+    /// This repository should have content write permissions with the github
+    /// app configuration.
+    ///
+    /// Should be a org/repo code, e.g., rust-lang/cargo.
+    pub(crate) cargo_tag_repository: Option<String>,
+
     /// Where to publish new blog PRs.
     ///
     /// We create a new PR announcing releases in this repository; currently we
@@ -219,6 +227,7 @@ impl Config {
             recompress_xz: bool_env("RECOMPRESS_XZ")?,
             recompress_gz: bool_env("RECOMPRESS_GZ")?,
             rustc_tag_repository: maybe_env("RUSTC_TAG_REPOSITORY")?,
+            cargo_tag_repository: maybe_env("CARGO_TAG_REPOSITORY")?,
             blog_repository: maybe_env("BLOG_REPOSITORY")?,
             blog_pr: maybe_env("BLOG_MERGE_PR")?,
             scheduled_release_date: maybe_env("BLOG_SCHEDULED_RELEASE_DATE")?,


### PR DESCRIPTION
This doesn't handle the crates.io releases, which we may want to do in GHA CI in response to the tagging event - that would allow us to reuse that infrastructure across rust-lang/rust rather than having something fully custom for promote release.

This hasn't been tested -- but is also almost entirely off by default until we set CARGO_TAG_REPOSITORY in production. I think we should merge and then next release we can drop that env if it doesn't work. In any case, tagging is pretty much the last step, so mostly harmless if this doesn't work.