### PR TITLE
Invalidate the cache on Fastly using surrogate keys

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -204,8 +204,8 @@ pub(crate) struct Config {
 
     /// An API token for Fastly with the `purge_select` scope.
     pub(crate) fastly_api_token: Option<String>,
-    /// The static domain name that is used with Fastly, e.g. `static.rust-lang.org`.
-    pub(crate) fastly_static_domain: Option<String>,
+    /// The Fastly service ID to purge when releasing.
+    pub(crate) fastly_service_id: Option<String>,
 
     /// Temporary variable to test Fastly in the dev environment only.
     pub(crate) invalidate_fastly: bool,
@@ -245,7 +245,7 @@ impl Config {
             github_app_key: maybe_env("GITHUB_APP_KEY")?,
             github_app_id: maybe_env("GITHUB_APP_ID")?,
             fastly_api_token: maybe_env("FASTLY_API_TOKEN")?,
-            fastly_static_domain: maybe_env("FASTLY_STATIC_DOMAIN")?,
+            fastly_service_id: maybe_env("FASTLY_SERVICE_ID")?,
             invalidate_fastly: bool_env("INVALIDATE_FASTLY")?,
         })
     }
@@ -270,8 +270,8 @@ impl Config {
     }
 
     pub(crate) fn fastly(&self) -> Option<Fastly> {
-        if let (Some(token), Some(domain)) = (&self.fastly_api_token, &self.fastly_static_domain) {
-            Some(Fastly::new(token.clone(), domain.clone()))
+        if let (Some(token), Some(service_id)) = (&self.fastly_api_token, &self.fastly_service_id) {
+            Some(Fastly::new(token.clone(), service_id.clone()))
         } else {
             None
         }

--- a/src/fastly.rs
+++ b/src/fastly.rs
@@ -3,15 +3,15 @@ use curl::easy::Easy;
 
 pub struct Fastly {
     api_token: String,
-    domain: String,
+    service_id: String,
     client: Easy,
 }
 
 impl Fastly {
-    pub fn new(api_token: String, domain: String) -> Self {
+    pub fn new(api_token: String, service_id: String) -> Self {
         Self {
             api_token,
-            domain,
+            service_id,
             client: Easy::new(),
         }
     }
@@ -19,8 +19,8 @@ impl Fastly {
     pub fn purge(&mut self, path: &str) -> Result<(), Error> {
         let sanitized_path = path.trim_start_matches('/');
         let url = format!(
-            "https://api.fastly.com/purge/{}/{}",
-            self.domain, sanitized_path
+            "https://api.fastly.com/service/{}/purge/{}",
+            self.service_id, sanitized_path
         );
 
         self.start_new_request()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -574,6 +574,9 @@ impl Context {
     }
 
     fn invalidate_releases(&self) -> Result<(), Error> {
+        // The following paths need to be added as surrogate keys to the Fastly service, otherwise
+        // they won't be invalidated. See the following pull request for an example:
+        // https://github.com/rust-lang/simpleinfra/pull/295
         let paths = ["/dist/*".into()];
 
         self.invalidate_cloudfront(&self.config.cloudfront_static_id, &paths)?;
@@ -626,15 +629,14 @@ impl Context {
             None => {
                 println!();
                 println!("WARNING! Skipped Fastly invalidation of: {:?}", paths);
-                println!("Set PROMOTE_RELEASE_FASTLY_API_TOKEN and PROMOTE_RELEASE_FASTLY_STATIC_DOMAIN if you want to invalidate Fastly");
+                println!("Set PROMOTE_RELEASE_FASTLY_API_TOKEN and PROMOTE_RELEASE_FASTLY_SERVICE_ID if you want to invalidate Fastly");
                 println!();
                 return Ok(());
             }
         };
 
         for path in paths {
-            let path = path.replace('*', "");
-            fastly.purge(&path)?;
+            fastly.purge(path)?;
         }
 
         Ok(())


### PR DESCRIPTION
Fastly does not support wildcard invalidations through its URL-based API, and also does not support invalidating a path prefix like `/dist/`. We are therefore switching to surrogate keys. Requests that match the path `^\/dist\/` get tagged with the surrogate key `/dist/*`, which is then used when invalidating the cache after a release.

The tagging implementation can be found in rust-lang/simpleinfra#295.