### PR TITLE
Simplify the surrogate key for Fastly

### DIFF
--- a/src/fastly.rs
+++ b/src/fastly.rs
@@ -17,10 +17,10 @@ impl Fastly {
     }
 
     pub fn purge(&mut self, path: &str) -> Result<(), Error> {
-        let sanitized_path = path.trim_start_matches('/');
+        let surrogate_key = path_to_surrogate_key(path);
         let url = format!(
             "https://api.fastly.com/service/{}/purge/{}",
-            self.service_id, sanitized_path
+            self.service_id, surrogate_key
         );
 
         self.start_new_request()?;
@@ -41,5 +41,23 @@ impl Fastly {
         headers.append("Content-Type: application/json")?;
         self.client.http_headers(headers)?;
         Ok(())
+    }
+}
+
+fn path_to_surrogate_key(path: &str) -> String {
+    path.chars().filter(|c| c.is_alphanumeric()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_to_surrogate_key_dist() {
+        let path = "/dist/*";
+
+        let surrogate_key = path_to_surrogate_key(path);
+
+        assert_eq!("dist", surrogate_key);
     }
 }


### PR DESCRIPTION
In the original implementation, we simply used the path for invalidations as the surrogate key. This worked fine when using the user interface to invalidate the cache, but broke when trying to use Fastly's API to do the same. While it is possible that we simply needed to URL-encode the key, a safer implementation is to avoid the problem in the first place by restricting the key to alphanumeric characters.