### PR TITLE
Revert "Debug logging during s3 operations"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -859,12 +859,6 @@ impl Context {
     fn aws_s3(&self) -> Command {
         let mut cmd = Command::new("aws");
 
-        // Log request IDs while we investigate an error coming from S3:
-        // [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1007)
-        //
-        // See https://github.com/rust-lang/promote-release/issues/77 for tracking for this.
-        cmd.arg("--debug");
-
         // Allow using non-S3 backends with the AWS CLI.
         if let Some(url) = &self.config.s3_endpoint_url {
             cmd.arg("--endpoint-url");


### PR DESCRIPTION
This reverts commit 075a92758d33eca17dfc2adef97f0673d5cd5965.

No issues seen since this was added, and it's *very* verbose. We've collected ~10 GB in the log group for releases as a result and it makes manually inspecting release logs more painful (e.g., during a release cycle).

My hope is that maybe the issue has gone away. Even if not, it seems plausible that the logging is sufficiently verbose it's hiding the issue due to changing how quickly things happen...