### PR TITLE
Fix synchronization of docs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -468,8 +468,12 @@ impl Context {
         let tarball_prefix = format!("rust-docs-{}-{}", version, target);
         let tarball = format!("{}.tar.gz", self.dl_dir().join(&tarball_prefix).display());
         let tarball_dir = format!("{}/rust-docs/share/doc/rust/html", tarball_prefix);
+
+        // The `m` flag touches all extracted files, therefore setting their modification time
+        // to the current date. This will cause the sync to overwrite all remote files with the
+        // local files.
         run(Command::new("tar")
-            .arg("xf")
+            .arg("xfm")
             .arg(&tarball)
             .arg("--strip-components=6")
             .arg(&tarball_dir)

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ impl Context {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(true)
             .open(self.work.join(".lock"))?;
         file.try_lock_exclusive()?;
         Ok(file)


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/123246, the docs archived have files with a modification time from 2006. This meant that `s3 sync` wouldn't upload them. This PR modifies our extraction logic to always set the modification time to the current date.