### PR TITLE
Implement release process for rustup

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,8 @@ impl std::fmt::Display for Channel {
     }
 }
 
+// Allow all variant names to start with `Promote`
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum Action {
     /// This is the default action, what we'll do if the environment variable
@@ -64,6 +66,13 @@ pub(crate) enum Action {
     /// * Create a rust-lang/cargo branch for the appropriate beta commit.
     /// * Post a PR against the newly created beta branch bump src/ci/channel to `beta`.
     PromoteBranches,
+
+    /// This promotes a new rustup release:
+    ///
+    /// * Copy binaries into archives
+    /// * Copy binaries from dev-static to production
+    /// * Update dev release number
+    PromoteRustup,
 }
 
 impl FromStr for Action {
@@ -73,6 +82,7 @@ impl FromStr for Action {
         match input {
             "promote-release" => Ok(Action::PromoteRelease),
             "promote-branches" => Ok(Action::PromoteBranches),
+            "promote-rustup" => Ok(Action::PromoteRustup),
             _ => anyhow::bail!("unknown action: {}", input),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,7 +73,7 @@ impl FromStr for Action {
         match input {
             "promote-release" => Ok(Action::PromoteRelease),
             "promote-branches" => Ok(Action::PromoteBranches),
-            _ => anyhow::bail!("unknown channel: {}", input),
+            _ => anyhow::bail!("unknown action: {}", input),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod discourse;
 mod fastly;
 mod github;
 mod recompress;
+mod rustup;
 mod sign;
 mod smoke_test;
 
@@ -76,6 +77,7 @@ impl Context {
         match self.config.action {
             config::Action::PromoteRelease => self.do_release()?,
             config::Action::PromoteBranches => self.do_branching()?,
+            config::Action::PromoteRustup => self.do_rustup()?,
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ impl Context {
         match self.config.action {
             config::Action::PromoteRelease => self.do_release()?,
             config::Action::PromoteBranches => self.do_branching()?,
-            config::Action::PromoteRustup => self.do_rustup()?,
+            config::Action::PromoteRustup => self.promote_rustup()?,
         }
         Ok(())
     }

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -1,7 +1,142 @@
-use crate::Context;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Error};
+
+use crate::config::Channel;
+use crate::{run, Context};
 
 impl Context {
-    pub fn do_rustup(&mut self) -> anyhow::Result<()> {
+    /// Promote a `rustup` release
+    ///
+    /// The [release process] for `rustup` involves copying existing artifacts from one S3 bucket to
+    /// another, updating the manifest, and archiving the artifacts for long-term storage.
+    ///
+    /// `rustup` uses different branches to manage releases. Whenever a commit is pushed to the
+    /// `stable` branch in [rust-lang/rustup], GitHub Actions workflows build release artifacts and
+    /// copy them into `s3://dev-static-rust-lang-org/rustup/dist/`.
+    ///
+    /// When a new release is done and this method is invoked, it downloads the artifacts from that
+    /// bucket (which must always be set as the `DOWNLOAD_BUCKET` variable). A copy of the artifacts
+    /// is archived in `s3://${UPLOAD_BUCKET}/rustup/archive/${version}/`, where `version` is passed
+    /// to this program as a command-line argument. `UPLOAD_BUCKET` can either be the `dev-static`
+    /// or the `static` bucket.
+    ///
+    /// If the release is for the `stable` channel, the artifacts are also copied to the `dist/`
+    /// path in the `UPLOAD_BUCKET` bucket. The `dist/` path is used by the `rustup` installer to
+    /// download the latest release.
+    ///
+    /// Then, the `release-stable.toml` manifest is updated with the new version and copied to
+    /// `s3://${UPLOAD_BUCKET}/rustup/release-stable.toml`.
+    ///
+    /// [release process]: https://rust-lang.github.io/rustup/dev-guide/release-process.html
+    /// [rust-lang/rustup]: https://github.com/rust-lang/rustup
+    pub fn promote_rustup(&mut self) -> anyhow::Result<()> {
+        println!("Checking channel...");
+        if self.config.channel != Channel::Stable && self.config.channel != Channel::Beta {
+            return Err(anyhow!(
+                "promoting rustup is only supported for the stable and beta channels"
+            ));
+        }
+
+        // Download the rustup artifacts from S3
+        println!("Downloading artifacts from dev-static...");
+        let dist_dir = self.download_rustup_artifacts()?;
+
+        // Archive the artifacts
+        println!("Archiving artifacts...");
+        self.archive_rustup_artifacts(&dist_dir)?;
+
+        if self.config.channel == Channel::Stable {
+            // Promote the artifacts to the release bucket
+            println!("Promoting artifacts to dist/...");
+            self.promote_rustup_artifacts(&dist_dir)?;
+        }
+
+        // Update the release number
+        println!("Updating version and manifest...");
+        self.update_rustup_release()?;
+
         Ok(())
+    }
+
+    fn download_rustup_artifacts(&mut self) -> Result<PathBuf, Error> {
+        let dl = self.dl_dir().join("dist");
+        // Remove the directory if it exists, otherwise just ignore.
+        let _ = fs::remove_dir_all(&dl);
+        fs::create_dir_all(&dl)?;
+
+        run(self
+            .aws_s3()
+            .arg("cp")
+            .arg("--recursive")
+            .arg("--only-show-errors")
+            .arg(&self.s3_artifacts_url("dist/"))
+            .arg(format!("{}/", dl.display())))?;
+
+        Ok(dl)
+    }
+
+    fn archive_rustup_artifacts(&mut self, dist_dir: &Path) -> Result<(), Error> {
+        let version = self
+            .current_version
+            .as_ref()
+            .ok_or_else(|| anyhow!("failed to get current version for rustup release"))?;
+
+        let path = format!("archive/{}/", version);
+
+        self.upload_rustup_artifacts(dist_dir, &path)
+    }
+
+    fn promote_rustup_artifacts(&mut self, dist_dir: &Path) -> Result<(), Error> {
+        let release_bucket_url = format!(
+            "s3://{}/{}/{}",
+            self.config.upload_bucket,
+            self.config.download_dir,
+            dist_dir.display(),
+        );
+
+        run(self
+            .aws_s3()
+            .arg("cp")
+            .arg("--recursive")
+            .arg("--only-show-errors")
+            .arg(format!("{}/", dist_dir.display()))
+            .arg(&release_bucket_url))
+    }
+
+    fn upload_rustup_artifacts(&mut self, dist_dir: &Path, target_path: &str) -> Result<(), Error> {
+        run(self
+            .aws_s3()
+            .arg("cp")
+            .arg("--recursive")
+            .arg("--only-show-errors")
+            .arg(format!("{}/", dist_dir.display()))
+            .arg(&self.s3_artifacts_url(target_path)))
+    }
+
+    fn update_rustup_release(&mut self) -> Result<(), Error> {
+        let version = self
+            .current_version
+            .as_ref()
+            .ok_or_else(|| anyhow!("failed to get current version for rustup release"))?;
+
+        let manifest_path = self.dl_dir().join("release-stable.toml");
+        let manifest = format!(
+            r#"
+schema-version = '1'
+version = '{}'
+            "#,
+            version
+        );
+
+        fs::write(&manifest_path, manifest)?;
+
+        run(self
+            .aws_s3()
+            .arg("cp")
+            .arg("--only-show-errors")
+            .arg(manifest_path)
+            .arg(&self.s3_artifacts_url("release-stable.toml")))
     }
 }

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -1,0 +1,7 @@
+use crate::Context;
+
+impl Context {
+    pub fn do_rustup(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
New versions of `rustup` are currently released manually by running the [`sync-dist.py`](https://github.com/rust-lang/rustup/blob/master/ci/sync-dist.py) script in the [rust-lang/rustup](https://github.com/rust-lang/rustup) repository multiple times. This process should be automated so that it reproducible and less error-prone. We also want to add more sanity checks in the future, which are more convenient to implement in Rust rather than in Python.

In https://github.com/rust-lang/rustup/pull/3819, we discussed reimplementing the script as part of `promote-release`. This pull request makes a first attempt at migrating the existing functionality into this repository.