### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         if: github.event_name == 'push' && github.repository == 'rust-lang/promote-release' && github.ref == 'refs/heads/master'
 
       - name: Upload the Docker image we built to GitHub Actions artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-image
           path: promote-release.tar.zstd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ---
-
 name: CI
 on:
   push:
@@ -46,13 +45,13 @@ jobs:
         run: rustup self update && rustup update stable
 
       - name: Start the local environment
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Run the local release process for channel ${{ matrix.channel }}
         run: ./run.sh ${{ matrix.channel }}
 
       - name: Validate the generated signatures
-        run: docker-compose exec -T local /src/local/check-signature.sh ${{ matrix.channel }}
+        run: docker compose exec -T local /src/local/check-signature.sh ${{ matrix.channel }}
 
       - name: Remove the previously installed ${{ matrix.channel }} toolchain
         run: rustup toolchain remove ${{ matrix.channel }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '3'
-
 services:
   minio:
     image: quay.io/minio/minio:RELEASE.2023-04-13T03-08-07Z

--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,7 @@ fi
 channel="$1"
 override_commit="${2-}"
 
-container_id="$(docker-compose ps -q local)"
+container_id="$(docker compose ps -q local)"
 if [[ "${container_id}" == "" ]]; then
     container_status="missing"
 else
@@ -22,7 +22,7 @@ if [[ "${container_status}" != "running" ]]; then
     echo "Error: the local environment is not running!"
     echo "You can start it by running in a new terminal the following command:"
     echo
-    echo "    docker-compose up"
+    echo "    docker compose up"
     echo
     exit 1
 fi
@@ -31,4 +31,4 @@ fi
 cargo build --release
 
 # Run the command inside the docker environment.
-docker-compose exec -T local /src/local/run.sh "${channel}" "${override_commit}"
+docker compose exec -T local /src/local/run.sh "${channel}" "${override_commit}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,7 +378,7 @@ impl Context {
             .arg("cp")
             .arg("--recursive")
             .arg("--only-show-errors")
-            .arg(&self.s3_artifacts_url(&format!("{}/", rev)))
+            .arg(self.s3_artifacts_url(&format!("{}/", rev)))
             .arg(format!("{}/", dl.display())))?;
 
         let mut files = dl.read_dir()?;


### PR DESCRIPTION
v2 of `actions/upload-artifact` is no longer supported and using it will fail any workflow immediately. v3 will be deprecated in a few months, so we are immediately upgrading to the latest version.

See https://github.com/actions/upload-artifact for more information.