### PR TITLE
Bump version of actions/download-artifact action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Download the Docker image previously built
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker-image
 


### PR DESCRIPTION
The actions/download-artifact action must be on the same version as the actions/upload-artifact action.