### PR TITLE
Update `manifests.txt` from the release process

### DIFF
--- a/src/branching.rs
+++ b/src/branching.rs
@@ -69,7 +69,7 @@ impl Context {
         let mut github = self.config.github().unwrap();
         let mut token = github.token("rust-lang/cargo")?;
         let new_beta = future_beta_version.content()?.trim().to_owned();
-        token.create_ref(&format!("refs/heads/rust-{}", new_beta), &cargo_sha)?;
+        token.create_ref(&format!("refs/heads/rust-{new_beta}"), &cargo_sha)?;
 
         Ok(())
     }

--- a/src/build_manifest.rs
+++ b/src/build_manifest.rs
@@ -84,7 +84,7 @@ impl<'a> BuildManifest<'a> {
     fn extract(builder: &'a Context) -> Result<NamedTempFile, Error> {
         let release = builder.config.channel.release_name(builder);
         let tarball_name = format!("build-manifest-{}-{}", release, crate::TARGET);
-        let tarball_path = builder.dl_dir().join(format!("{}.tar.xz", tarball_name));
+        let tarball_path = builder.dl_dir().join(format!("{tarball_name}.tar.xz"));
 
         let binary_path = Path::new(&tarball_name)
             .join("build-manifest")

--- a/src/config.rs
+++ b/src/config.rs
@@ -333,10 +333,9 @@ where
     R: FromStr,
     Error: From<R::Err>,
 {
-    match std::env::var(format!("{}{}", ENVIRONMENT_VARIABLE_PREFIX, name)) {
+    match std::env::var(format!("{ENVIRONMENT_VARIABLE_PREFIX}{name}")) {
         Ok(val) => Ok(Some(val.parse().map_err(Error::from).context(format!(
-            "the {} environment variable has invalid content",
-            name
+            "the {name} environment variable has invalid content"
         ))?)),
         Err(VarError::NotPresent) => Ok(None),
         Err(VarError::NotUnicode(_)) => {

--- a/src/fastly.rs
+++ b/src/fastly.rs
@@ -28,7 +28,7 @@ impl Fastly {
         self.client.post(true)?;
         self.client.url(&url)?;
 
-        println!("invalidating Fastly cache with POST '{}'", url);
+        println!("invalidating Fastly cache with POST '{url}'");
 
         self.client.perform().map_err(|error| error.into())
     }

--- a/src/github.rs
+++ b/src/github.rs
@@ -74,8 +74,7 @@ impl Github {
         self.start_jwt_request()?;
         self.client.get(true)?;
         self.client.url(&format!(
-            "https://api.github.com/repos/{}/installation",
-            repository
+            "https://api.github.com/repos/{repository}/installation"
         ))?;
         #[derive(serde::Deserialize)]
         struct InstallationResponse {
@@ -174,7 +173,7 @@ impl RepositoryClient<'_> {
             .client
             .with_body(&request)
             .send_with_response::<CreatedTag>()
-            .with_context(|| format!("tag request {:?}", request))?;
+            .with_context(|| format!("tag request {request:?}"))?;
 
         self.create_ref(&format!("refs/tags/{}", tag.tag_name), &created.sha)?;
 
@@ -407,7 +406,7 @@ impl RepositoryClient<'_> {
         self.client.url(&format!(
             "https://api.github.com/repos/{repo}/contents/{path}{maybe_ref}",
             repo = self.repo,
-            maybe_ref = sha.map(|s| format!("?ref={}", s)).unwrap_or_default()
+            maybe_ref = sha.map(|s| format!("?ref={s}")).unwrap_or_default()
         ))?;
         self.client.without_body().send_with_response::<GitFile>()
     }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -111,7 +111,7 @@ impl Signer {
 
         std::fs::write(
             add_suffix(path, ".sha256"),
-            format!("{}  {}\n", sha256, file_name),
+            format!("{sha256}  {file_name}\n"),
         )?;
 
         Ok(())
@@ -162,7 +162,7 @@ impl Signer {
         // git to avoid a dependency on the ~global gpg home directory's signing
         // keys (and potential need to enter the signing key password). This
         // also lets us more tightly control what we're signing.
-        let mut message = format!("{}\n", message);
+        let mut message = format!("{message}\n");
         let mut payload = format!("object {commit}\ntype commit\ntag {tag}\n");
         let timestamp = now.timestamp();
         write!(

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -79,7 +79,7 @@ impl SmokeTester {
         let cargo = |args: &[&str]| {
             crate::run(
                 Command::new("cargo")
-                    .arg(format!("+{}", channel))
+                    .arg(format!("+{channel}"))
                     .args(args)
                     .env("USER", "root")
                     .current_dir(&cargo_dir),


### PR DESCRIPTION
Right now https://static.rust-lang.org/manifests.txt is uploaded by [generate-manifest-list](https://github.com/rust-lang/generate-manifest-list/), in a cron running every week. This is an extra bit of infrastructure to maintain and means the list is often out of date.

This PR moves updating manifests.txt to the release process. Once it's merged we can retire the old tool.

Since multiple release processes can run at the same time, there is a chance they'd try to update manifests.txt at the same time, potentially overriding each other's work. To avoid that I use conditional writes in a retry loop.