### PR TITLE
Followup fixes to `manifests.txt`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod sign;
 mod smoke_test;
 
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
@@ -711,6 +711,9 @@ impl Context {
             // Setting the If-None-Match header to * will fail the request if the file exists.
             Err(_) => ("--if-none-match", "*".to_string()),
         };
+
+        // Append the new item at the end of the manifest.
+        manifest.seek(SeekFrom::End(0))?;
 
         let upload_addr = self
             .config


### PR DESCRIPTION
This PR contains multiple fixes to #89:

* It now uses `--if-match` instead of `--if-none-match` when the file exists already, as noted in https://github.com/rust-lang/promote-release/pull/89#discussion_r2181330756
* It adds new manifests at the bottom of the file rather than at the top
* It handles releases with multiple manifests (for example, one for `beta` and one for `1.89-beta` in the case of beta releases)

I managed to test them locally and everything seems to work fine.