### PR TITLE
Set content-type for `manifests.txt`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -744,6 +744,7 @@ impl Context {
             .arg(manifest.path())
             .args(["--bucket", &self.config.upload_bucket])
             .args(["--key", "manifests.txt"])
+            .args(["--content-type", "text/plain"])
             // Fail the request if the manifest was already modified by something else (for
             // example, another release running in parallel).
             .args([conditional_header, &conditional_value]))?;


### PR DESCRIPTION
By default S3 treats uploaded files without a content-type as binary blobs, which results in the browser downloading it when visiting the URL. Setting the content-type to text/plain lets the browser render it.

Last PR for this feature :D