### PR TITLE
Fix manifests.txt invalidation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -603,7 +603,7 @@ impl Context {
     }
 
     fn invalidate_manifests_txt(&self) -> Result<(), Error> {
-        self.invalidate_all_cdns(&["manifests.txt".into()])
+        self.invalidate_all_cdns(&["/manifests.txt".into()])
     }
 
     fn invalidate_all_cdns(&self, paths: &[String]) -> Result<(), Error> {


### PR DESCRIPTION
The run yesterday failed
```
running "aws" "cloudfront" "create-invalidation" "--invalidation-batch" "file:///codebuild/output/src2735315778/src/release/payload.json" "--distribution-id" "E3NZU1LCBHH4A4"
An error occurred (InvalidArgument) when calling the CreateInvalidation operation: Your request contains one or more invalid invalidation paths.
```

And the docs say
> In the CloudFront console, you can omit the leading slash in the path, like this: images/image2.jpg. When you use the CloudFront API directly, invalidation paths must begin with a leading slash.

So looks like that's the bug.