### PR TITLE
Increase XZ recompress dictionary size to 128 MiB

### DIFF
--- a/src/recompress.rs
+++ b/src/recompress.rs
@@ -55,7 +55,7 @@ pub(crate) fn recompress_file(
         let mut lzma_ops = xz2::stream::LzmaOptions::new_preset(9).unwrap();
         // This sets the overall dictionary size, which is also how much memory (baseline)
         // is needed for decompression.
-        lzma_ops.dict_size(64 * 1024 * 1024);
+        lzma_ops.dict_size(128 * 1024 * 1024);
         // Use the best match finder for compression ratio.
         lzma_ops.match_finder(xz2::stream::MatchFinder::BinaryTree4);
         lzma_ops.mode(xz2::stream::Mode::Normal);


### PR DESCRIPTION
This increases peak RSS for users of Rustup by 64 MiB in exchange for non-negligible improvements in compression ratio for the larger tarballs:
```
# component    bytes_un    bytes_cur   bytes_128m   ratio
rust-docs   :  669916672   21485344    20294200    -5.543984%
rustc       :  386717696   82519204    76896156    -6.81423 %
llvm-tools  :  194253312   39117832    36593820    -6.45233 %
rust-std    :  163678208   29115852    28910652    -0.70477 %
cargo       :   42116608   10679724    10679732    +0.000075%
rust-src    :   40181760    3473408     3473416    +0.00023 %
clippy      :   21029376    4544900     4544908    +0.00018 %
rustfmt     :    9690624    2255472     2255480    +0.00035 %
```
All tests were done on tarballs from `https://static.rust-lang.org/dist/2025-09-18/{component}-1.90.0-x86_64-unknown-linux-gnu.tar.xz`. The size of the compressed tarballs directly downloaded from static.rust-lang.org is shown in the `bytes_cur` column.

`bytes_128m` is the size of the output of `xz -T1 --lzma=preset=9e,depth=1000,dict=128M`, which is the same configuration as what `prepare-release` does with the change this pull request makes.
The version used is XZ Utils 5.8.1 from Arch Linux repositories. The `cargo`, `rust-src`, `clippy` and `rustfmt` components (all smaller than 128 MiB) appearing as having regressed by exactly 8 bytes is likely a mismatch between the compressor version information written by `xz` and that written by `prepare-release`, so the 8-byte increase will probably not show up in actuality.

I have confirmed via GNU Time (`/bin/time -v`) that decompressor memory usage increases by no more than 64 MiB.