### PR TITLE
Update dependencies & fix GitHub commit signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "bytes",
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,6 +28,38 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -33,6 +76,19 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+ "zeroize",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -54,12 +110,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -71,10 +121,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bitfield"
-version = "0.14.0"
+name = "bitfields"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
+dependencies = [
+ "bitfields-impl",
+]
+
+[[package]]
+name = "bitfields-impl"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
 
 [[package]]
 name = "bitflags"
@@ -83,12 +148,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -108,16 +203,6 @@ checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
  "cipher",
-]
-
-[[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -223,8 +308,19 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
+]
+
+[[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -232,6 +328,21 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -316,7 +427,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -358,7 +488,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -373,14 +503,31 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
+]
+
+[[package]]
+name = "cx448"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
+dependencies = [
+ "crypto-bigint",
+ "elliptic-curve",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "serdect 0.3.0",
+ "sha3",
+ "signature",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -388,38 +535,36 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
-name = "der"
-version = "0.6.1"
+name = "dbl"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
 dependencies = [
- "const-oid",
- "pem-rfc7468 0.6.0",
- "zeroize",
+ "generic-array",
 ]
 
 [[package]]
@@ -428,40 +573,63 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
- "pem-rfc7468 0.7.0",
+ "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
 [[package]]
 name = "derive_builder"
-version = "0.12.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.12.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.12.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.109",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -479,10 +647,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -493,7 +672,36 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
+]
+
+[[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8",
+ "rfc6979",
+ "sha2 0.10.9",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "eax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
+dependencies = [
+ "aead",
+ "cipher",
+ "cmac",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -502,12 +710,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
- "digest",
+ "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki 0.7.3",
+ "spki",
 ]
 
 [[package]]
@@ -516,7 +724,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
+ "pkcs8",
  "signature",
 ]
 
@@ -528,8 +736,9 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -547,17 +756,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
+ "base64ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serde_json",
+ "serdect 0.2.0",
  "subtle",
+ "tap",
  "zeroize",
 ]
 
@@ -589,6 +802,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -624,6 +838,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -656,6 +871,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -718,6 +939,16 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -794,7 +1025,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -842,6 +1073,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1073,6 +1313,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.9",
+ "signature",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,7 +1450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1204,12 +1458,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1234,12 +1482,11 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1257,17 +1504,6 @@ dependencies = [
  "serde",
  "smallvec",
  "zeroize",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1311,10 +1547,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -1343,7 +1619,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1355,16 +1631,32 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.6.0"
+name = "p521"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1384,51 +1676,67 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pgp"
-version = "0.10.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e1f8e085bfa9b85763fe3ddaacbe90a09cd847b3833129153a6cb063bbe132"
+checksum = "eaffe1ec22db286599c30ae6be75b37493b558735d86c8e59ec5c38794415fe4"
 dependencies = [
+ "aead",
  "aes",
- "base64 0.21.7",
- "bitfield",
+ "aes-gcm",
+ "aes-kw",
+ "argon2",
+ "base64",
+ "bitfields",
  "block-padding",
  "blowfish",
- "bstr",
  "buffer-redux",
  "byteorder",
+ "bytes",
  "camellia",
  "cast5",
  "cfb-mode",
- "chrono",
  "cipher",
+ "const-oid 0.9.6",
  "crc24",
  "curve25519-dalek",
+ "cx448",
  "derive_builder",
+ "derive_more",
  "des",
- "digest",
+ "digest 0.10.7",
+ "dsa",
+ "eax",
+ "ecdsa",
  "ed25519-dalek",
  "elliptic-curve",
  "flate2",
  "generic-array",
  "hex",
+ "hkdf",
  "idea",
+ "k256",
  "log",
  "md-5",
  "nom",
  "num-bigint-dig",
- "num-derive",
  "num-traits",
+ "num_enum",
+ "ocb3",
  "p256",
  "p384",
+ "p521",
  "rand 0.8.5",
+ "regex",
+ "replace_with",
  "ripemd",
- "rsa 0.9.10",
+ "rsa",
  "sha1",
- "sha2",
+ "sha1-checked",
+ "sha2 0.10.9",
  "sha3",
  "signature",
  "smallvec",
- "thiserror",
+ "snafu",
  "twofish",
  "x25519-dalek",
  "zeroize",
@@ -1448,35 +1756,13 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
-dependencies = [
- "der 0.6.1",
- "pkcs8 0.9.0",
- "spki 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -1485,8 +1771,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -1500,6 +1786,18 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1526,7 +1824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1536,6 +1834,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1552,7 +1859,7 @@ name = "promote-release"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "curl",
@@ -1566,11 +1873,12 @@ dependencies = [
  "num_cpus",
  "pgp",
  "rand 0.10.0",
+ "rand 0.8.5",
  "rayon",
- "rsa 0.8.2",
+ "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "tempfile",
  "tokio",
@@ -1598,6 +1906,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1676,6 +1990,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,27 +2040,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest",
-]
-
-[[package]]
-name = "rsa"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
-dependencies = [
- "byteorder",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-iter",
- "num-traits",
- "pkcs1 0.4.1",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "signature",
- "subtle",
- "zeroize",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1720,16 +2049,17 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1 0.7.5",
- "pkcs8 0.10.2",
+ "pkcs1",
+ "pkcs8",
  "rand_core 0.6.4",
+ "sha2 0.10.9",
  "signature",
- "spki 0.7.3",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -1778,9 +2108,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.10",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -1818,7 +2149,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1844,6 +2175,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,7 +2202,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1862,7 +2224,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1871,7 +2244,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -1887,7 +2260,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -1902,6 +2275,27 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "socket2"
@@ -1921,22 +2315,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -1947,26 +2331,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1987,8 +2360,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -2016,22 +2395,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2066,7 +2445,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2091,6 +2470,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.8+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -2130,10 +2521,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "url"
@@ -2221,7 +2628,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2311,7 +2718,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2322,7 +2729,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2436,6 +2843,9 @@ name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2467,7 +2877,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2483,7 +2893,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2530,6 +2940,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -2581,7 +3000,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -2602,7 +3021,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2622,7 +3041,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -2643,7 +3062,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2676,8 +3095,14 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,10 @@ hyper-util = { version = "0.1.20", features = ["http1", "server", "server-gracef
 num_cpus = "1.13.0"
 http-body-util = { version = "0.1.3", features = ["full"] }
 bytes = "1.11.1"
+
+# Optimize select dependencies to speed up dev build tests
+# The num-bigint crate is used to generate an RSA key for the signature tests
+# which is slow (~1.5 minutes vs. 4 seconds) in debug mode.
+[profile.dev.package.num-bigint-dig]
+opt-level = 3
+overflow-checks = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,12 @@ rand = "0.10"
 xz2 = "0.1"
 anyhow = "1.0.32"
 rayon = "1.4.0"
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4.2"
-pgp = "0.10"
-rsa = "0.8"
+pgp = { version = "0.19", default-features = false }
+# pgp still depends on rand v0.8, but does not re-export it. So we need our own dependency on it.
+rand_pgp = { version = "0.8", package = "rand" }
+rsa = { version = "0.9.10", features = ["sha2"] }
 base64 = "0.22"
 chrono = "0.4.19"
 git2 = "0.20.4"

--- a/src/github.rs
+++ b/src/github.rs
@@ -147,6 +147,7 @@ impl RepositoryClient<'_> {
         struct CreateTagTaggerInternal<'a> {
             name: &'a str,
             email: &'a str,
+            date: String,
         }
 
         #[derive(serde::Deserialize)]
@@ -167,6 +168,8 @@ impl RepositoryClient<'_> {
             tagger: CreateTagTaggerInternal {
                 name: tag.tagger_name,
                 email: tag.tagger_email,
+                // ISO 8601 format
+                date: tag.timestamp.format("%Y-%m-%dT%H:%M:%S%Z").to_string(),
             },
         };
         let created = self
@@ -521,6 +524,7 @@ pub(crate) struct CreateTag<'a> {
     pub(crate) message: &'a str,
     pub(crate) tagger_name: &'a str,
     pub(crate) tagger_email: &'a str,
+    pub(crate) timestamp: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(serde::Deserialize)]

--- a/src/github.rs
+++ b/src/github.rs
@@ -43,7 +43,7 @@ impl Github {
         let signature = self
             .key
             .sign(
-                rsa::pkcs1v15::Pkcs1v15Sign::new::<sha2::Sha256>(),
+                rsa::pkcs1v15::Pkcs1v15Sign::new::<rsa::sha2::Sha256>(),
                 &sha2::Sha256::new()
                     .chain_update(format!(
                         "{}.{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -835,7 +835,7 @@ impl Context {
         let tag_name = version.to_owned();
         let username = "rust-lang/promote-release";
         let email = "release-team@rust-lang.org";
-        let message = signer.git_signed_tag(
+        let (message, timestamp) = signer.git_signed_tag(
             commit,
             &tag_name,
             username,
@@ -846,10 +846,10 @@ impl Context {
         github.token(repository)?.tag(CreateTag {
             commit,
             tag_name: &tag_name,
-            // FIXME: we need to pass the timestamp too
-            message: &message.0,
+            message: &message,
             tagger_name: username,
             tagger_email: email,
+            timestamp,
         })?;
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -846,7 +846,8 @@ impl Context {
         github.token(repository)?.tag(CreateTag {
             commit,
             tag_name: &tag_name,
-            message: &message,
+            // FIXME: we need to pass the timestamp too
+            message: &message.0,
             tagger_name: username,
             tagger_email: email,
         })?;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -26,14 +26,21 @@ pub(crate) struct Signer {
 }
 
 impl Signer {
-    pub(crate) fn new(config: &Config) -> Result<Self, Error> {
-        let mut key_file = File::open(&config.gpg_key_file)?;
-        let gpg_password = std::fs::read_to_string(&config.gpg_password_file)?;
+    fn new_inner(gpg_key_file: &Path, gpg_password_file: &Path) -> Result<Self, Error> {
+        let mut key_file = File::open(gpg_key_file)?;
+        let gpg_password = std::fs::read_to_string(gpg_password_file)?;
         Ok(Signer {
             gpg_key: SignedSecretKey::from_armor_single(&mut key_file)?.0,
             gpg_password,
             sha256_checksum_cache: HashMap::new(),
         })
+    }
+
+    pub(crate) fn new(config: &Config) -> Result<Self, Error> {
+        Self::new_inner(
+            Path::new(&config.gpg_key_file),
+            Path::new(&config.gpg_password_file),
+        )
     }
 
     pub(crate) fn override_checksum_cache(&mut self, new: HashMap<PathBuf, String>) {
@@ -153,7 +160,7 @@ impl Signer {
         username: &str,
         email: &str,
         message: &str,
-    ) -> Result<String, Error> {
+    ) -> Result<(String, chrono::DateTime<chrono::Utc>), Error> {
         let key_function = || self.gpg_password.trim().to_string();
 
         let now = chrono::Utc::now();
@@ -202,7 +209,7 @@ impl Signer {
         pgp::armor::write(&content, BlockType::Signature, &mut dest, None)?;
         message.push_str(&String::from_utf8(dest)?);
 
-        Ok(message)
+        Ok((message, now))
     }
 }
 
@@ -223,3 +230,6 @@ fn add_suffix(path: &Path, suffix: &str) -> PathBuf {
     path.set_file_name(file_name);
     path
 }
+
+#[cfg(all(test, unix))]
+mod test;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,11 +1,10 @@
-use anyhow::Error;
-use chrono::Utc;
+use anyhow::{Context, Error};
 use pgp::{
-    Deserializable, SignedSecretKey,
     armor::BlockType,
+    composed::{Deserializable, SignedSecretKey},
     crypto::hash::HashAlgorithm,
-    packet::{self, Packet, SignatureConfig, SignatureType, SignatureVersion},
-    types::{KeyTrait, SecretKeyTrait},
+    packet::{self, Packet, SignatureConfig, SignatureType},
+    types::{KeyDetails, Timestamp},
 };
 use rayon::prelude::*;
 use sha2::Digest;
@@ -21,7 +20,7 @@ use crate::config::Config;
 
 pub(crate) struct Signer {
     gpg_key: SignedSecretKey,
-    gpg_password: String,
+    gpg_password: pgp::types::Password,
     sha256_checksum_cache: HashMap<PathBuf, String>,
 }
 
@@ -31,7 +30,7 @@ impl Signer {
         let gpg_password = std::fs::read_to_string(gpg_password_file)?;
         Ok(Signer {
             gpg_key: SignedSecretKey::from_armor_single(&mut key_file)?.0,
-            gpg_password,
+            gpg_password: pgp::types::Password::from(gpg_password.trim().to_owned()),
             sha256_checksum_cache: HashMap::new(),
         })
     }
@@ -125,28 +124,30 @@ impl Signer {
     }
 
     fn gpg_sign(&self, path: &Path, data: &[u8]) -> Result<(), Error> {
-        let key_function = || self.gpg_password.trim().to_string();
-        let now = Utc::now();
-
         let pubkey = self.gpg_key.public_key();
-        let sign_config = SignatureConfig {
-            version: SignatureVersion::V4,
-            typ: SignatureType::Binary,
-            pub_alg: self.gpg_key.algorithm(),
-            hash_alg: HashAlgorithm::SHA2_512,
-            issuer: Some(pubkey.key_id()),
-            created: Some(now),
-            hashed_subpackets: vec![
-                packet::Subpacket::regular(packet::SubpacketData::SignatureCreationTime(now)),
-                packet::Subpacket::regular(packet::SubpacketData::Issuer(pubkey.key_id())),
-            ],
-            unhashed_subpackets: Vec::new(),
-        };
-
+        let mut sign_config = SignatureConfig::v4(
+            SignatureType::Binary,
+            self.gpg_key.algorithm(),
+            HashAlgorithm::Sha512,
+        );
+        sign_config
+            .hashed_subpackets
+            .push(packet::Subpacket::regular(
+                packet::SubpacketData::SignatureCreationTime(Timestamp::now()),
+            )?);
+        sign_config
+            .hashed_subpackets
+            .push(packet::Subpacket::regular(
+                // FIXME: Should we also include the IssuerFingerprint?
+                packet::SubpacketData::IssuerKeyId(pubkey.legacy_key_id()),
+            )?);
         let mut dest = File::create(add_suffix(path, ".asc"))?;
 
-        let content = Packet::from(sign_config.sign(&self.gpg_key, key_function, data)?);
-        pgp::armor::write(&content, BlockType::Signature, &mut dest, None)?;
+        let content =
+            Packet::from(sign_config.sign(&self.gpg_key.primary_key, &self.gpg_password, data)?);
+        // We include a CRC24 checksum because pgp v0.10 did (trying to avoid functional changes
+        // during upgrade).
+        pgp::armor::write(&content, BlockType::Signature, &mut dest, None, true)?;
 
         Ok(())
     }
@@ -161,8 +162,6 @@ impl Signer {
         email: &str,
         message: &str,
     ) -> Result<(String, chrono::DateTime<chrono::Utc>), Error> {
-        let key_function = || self.gpg_password.trim().to_string();
-
         let now = chrono::Utc::now();
         // This was discovered by running git tag with a custom gpg bin set and
         // capturing the signed text; we avoid calling out to gpg from within
@@ -184,29 +183,36 @@ impl Signer {
         // The packets here match the ones used by git when signing tags; it's
         // not necessarily the case that they're exactly what's needed but this
         // seems to work well in practice.
-        let sign_config = SignatureConfig {
-            version: SignatureVersion::V4,
-            typ: SignatureType::Binary,
-            pub_alg: self.gpg_key.algorithm(),
-            hash_alg: HashAlgorithm::SHA2_512,
-            issuer: Some(pubkey.key_id()),
-            created: Some(now),
-            hashed_subpackets: vec![
-                packet::Subpacket::regular(packet::SubpacketData::IssuerFingerprint(
-                    pgp::types::KeyVersion::V4,
-                    self.gpg_key.public_key().fingerprint().into(),
+        let mut sign_config = SignatureConfig::v4(
+            SignatureType::Binary,
+            self.gpg_key.algorithm(),
+            HashAlgorithm::Sha512,
+        );
+        sign_config
+            .hashed_subpackets
+            .push(packet::Subpacket::regular(
+                packet::SubpacketData::IssuerFingerprint(pubkey.fingerprint()),
+            )?);
+        sign_config
+            .hashed_subpackets
+            .push(packet::Subpacket::regular(
+                packet::SubpacketData::SignatureCreationTime(Timestamp::from_secs(
+                    now.timestamp().try_into().context("timestamp too large")?,
                 )),
-                packet::Subpacket::regular(packet::SubpacketData::SignatureCreationTime(now)),
-            ],
-            unhashed_subpackets: vec![packet::Subpacket::regular(packet::SubpacketData::Issuer(
-                pubkey.key_id(),
-            ))],
-        };
+            )?);
+        sign_config
+            .unhashed_subpackets
+            .push(packet::Subpacket::regular(
+                packet::SubpacketData::IssuerKeyId(pubkey.legacy_key_id()),
+            )?);
 
         let mut dest = Vec::new();
-        let content =
-            Packet::from(sign_config.sign(&self.gpg_key, key_function, payload.as_bytes())?);
-        pgp::armor::write(&content, BlockType::Signature, &mut dest, None)?;
+        let content = Packet::from(sign_config.sign(
+            &self.gpg_key.primary_key,
+            &self.gpg_password,
+            payload.as_bytes(),
+        )?);
+        pgp::armor::write(&content, BlockType::Signature, &mut dest, None, true)?;
         message.push_str(&String::from_utf8(dest)?);
 
         Ok((message, now))

--- a/src/sign/test.rs
+++ b/src/sign/test.rs
@@ -1,0 +1,229 @@
+use pgp::composed::{KeyType, SecretKeyParamsBuilder, SignedSecretKey};
+use pgp::types::SecretKeyTrait;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+use super::Signer;
+
+fn test_signer(parent_dir: &Path) -> (Signer, NamedTempFile) {
+    let mut key_file = NamedTempFile::new_in(parent_dir).unwrap();
+    let mut password_file = NamedTempFile::new_in(parent_dir).unwrap();
+
+    let password = "secure password";
+    password_file.write_all(password.as_bytes()).unwrap();
+
+    let mut key_params = SecretKeyParamsBuilder::default();
+    key_params
+        .key_type(KeyType::Rsa(4096))
+        .can_sign(true)
+        .can_create_certificates(false)
+        .passphrase(Some(password.to_owned()))
+        .primary_user_id("Me <me@example.com>".into());
+    let secret_key_params = key_params
+        .build()
+        .expect("Must be able to create secret key params");
+
+    eprintln!("Generating secret key...");
+
+    let secret_key = secret_key_params
+        .generate()
+        .expect("Failed to generate a plain key.");
+
+    let signed_secret_key: SignedSecretKey = secret_key.sign(|| password.to_owned()).unwrap();
+
+    eprintln!("Serializing secret key...");
+
+    signed_secret_key
+        .to_armored_writer(&mut key_file, Default::default())
+        .unwrap();
+
+    let mut pubkey = NamedTempFile::new_in(parent_dir).unwrap();
+    signed_secret_key
+        .public_key()
+        .sign(&signed_secret_key, || password.to_owned())
+        .unwrap()
+        .to_armored_writer(&mut pubkey, Default::default())
+        .unwrap();
+
+    eprintln!("Wrote fresh secret key to file");
+
+    (
+        Signer::new_inner(key_file.path(), password_file.path()).unwrap(),
+        pubkey,
+    )
+}
+
+#[test]
+fn artifact() {
+    let parent_dir = tempfile::tempdir().unwrap();
+    let (signer, pubkey) = test_signer(parent_dir.path());
+
+    let mut channel_file = tempfile::Builder::new()
+        .prefix("fake-channel-manifest")
+        .tempfile_in(parent_dir.path())
+        .unwrap();
+    channel_file.write_all(b"hello world").unwrap();
+    signer.sign(channel_file.path()).unwrap();
+
+    let gpg_home = tempfile::Builder::new()
+        .permissions(std::fs::Permissions::from_mode(0o700))
+        .tempdir_in(parent_dir.path())
+        .unwrap();
+
+    let mut gpg = std::process::Command::new("gpg");
+    let status = gpg
+        .env("GNUPGHOME", gpg_home.path())
+        .arg("--import")
+        .arg(pubkey.path())
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let mut gpg = std::process::Command::new("gpg");
+    gpg.env("GNUPGHOME", gpg_home.path())
+        .arg("--armor")
+        .arg("--pinentry-mode")
+        .arg("loopback")
+        .arg("--verify")
+        .arg(channel_file.path().with_added_extension("asc"))
+        .arg(&channel_file.path());
+    eprintln!("Running {:?}", gpg);
+    let status = gpg.status().unwrap();
+    assert!(status.success());
+
+    // sha256sum -c "channel-rust-${channel}.toml.sha256"
+    let status = dbg!(
+        std::process::Command::new("sha256sum")
+            .current_dir(parent_dir.path())
+            .arg("-c")
+            .arg(channel_file.path().with_added_extension("sha256"))
+    )
+    .status()
+    .unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn git_tag() {
+    let parent_dir = tempfile::tempdir().unwrap();
+    let (signer, pubkey) = test_signer(parent_dir.path());
+
+    assert!(
+        std::process::Command::new("git")
+            .current_dir(parent_dir.path())
+            .arg("init")
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    assert!(
+        std::process::Command::new("git")
+            .current_dir(parent_dir.path())
+            .env("GIT_AUTHOR_NAME", "Me")
+            .env("GIT_AUTHOR_EMAIL", "me@example.com")
+            .env("GIT_COMMITTER_NAME", "Me")
+            .env("GIT_COMMITTER_EMAIL", "me@example.com")
+            .arg("commit")
+            .arg("--allow-empty")
+            .arg("--message")
+            .arg("first commit")
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    let commit_hash = std::process::Command::new("git")
+        .current_dir(parent_dir.path())
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .unwrap();
+    assert!(commit_hash.status.success(), "{:?}", commit_hash);
+    let commit_hash = String::from_utf8(commit_hash.stdout).unwrap();
+    let commit_hash = commit_hash.trim();
+
+    let tag_name = "test-tag";
+    let username = "Me";
+    let email = "me@example.com";
+    let (message, timestamp) = signer
+        .git_signed_tag(
+            dbg!(commit_hash),
+            &tag_name,
+            username,
+            email,
+            &format!("test-tag #1"),
+        )
+        .unwrap();
+
+    let mut message_file = tempfile::NamedTempFile::new_in(parent_dir.path()).unwrap();
+    message_file.write_all(message.as_bytes()).unwrap();
+
+    assert!(
+        std::process::Command::new("git")
+            .current_dir(parent_dir.path())
+            .env("GIT_AUTHOR_NAME", "Me")
+            .env("GIT_AUTHOR_EMAIL", "me@example.com")
+            .env("GIT_COMMITTER_NAME", "Me")
+            .env("GIT_COMMITTER_EMAIL", "me@example.com")
+            // Note: This is critical. `git-tag` internally produces a tag whose payload contains
+            // this datel. The signed message *must* match that date exactly (otherwise it's not
+            // signing the right payload).
+            .env(
+                "GIT_COMMITTER_DATE",
+                format!("{} +0000", timestamp.timestamp())
+            )
+            .arg("tag")
+            .arg("-a")
+            .arg("--cleanup=verbatim")
+            .arg("-F")
+            .arg(message_file.path())
+            .arg(&tag_name)
+            .arg(&commit_hash)
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    let gpg_home = tempfile::Builder::new()
+        .permissions(std::fs::Permissions::from_mode(0o700))
+        .tempdir_in(parent_dir.path())
+        .unwrap();
+
+    let mut gpg = std::process::Command::new("gpg");
+    let status = gpg
+        .env("GNUPGHOME", gpg_home.path())
+        .arg("--import")
+        .arg(pubkey.path())
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    println!("### git show tag:");
+    assert!(
+        std::process::Command::new("git")
+            .current_dir(parent_dir.path())
+            .env("GNUPGHOME", gpg_home.path())
+            .arg("show")
+            .arg("--format=raw")
+            .arg(&tag_name)
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    println!("### git verify-tag:");
+    assert!(
+        std::process::Command::new("git")
+            .current_dir(parent_dir.path())
+            .env("GNUPGHOME", gpg_home.path())
+            .arg("verify-tag")
+            .arg("--verbose")
+            .arg(&tag_name)
+            .status()
+            .unwrap()
+            .success()
+    );
+}

--- a/src/sign/test.rs
+++ b/src/sign/test.rs
@@ -1,5 +1,4 @@
-use pgp::composed::{KeyType, SecretKeyParamsBuilder, SignedSecretKey};
-use pgp::types::SecretKeyTrait;
+use pgp::composed::{KeyType, SecretKeyParamsBuilder};
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -18,7 +17,6 @@ fn test_signer(parent_dir: &Path) -> (Signer, NamedTempFile) {
     key_params
         .key_type(KeyType::Rsa(4096))
         .can_sign(true)
-        .can_create_certificates(false)
         .passphrase(Some(password.to_owned()))
         .primary_user_id("Me <me@example.com>".into());
     let secret_key_params = key_params
@@ -27,11 +25,9 @@ fn test_signer(parent_dir: &Path) -> (Signer, NamedTempFile) {
 
     eprintln!("Generating secret key...");
 
-    let secret_key = secret_key_params
-        .generate()
+    let signed_secret_key = secret_key_params
+        .generate(&mut rand_pgp::thread_rng())
         .expect("Failed to generate a plain key.");
-
-    let signed_secret_key: SignedSecretKey = secret_key.sign(|| password.to_owned()).unwrap();
 
     eprintln!("Serializing secret key...");
 
@@ -41,9 +37,7 @@ fn test_signer(parent_dir: &Path) -> (Signer, NamedTempFile) {
 
     let mut pubkey = NamedTempFile::new_in(parent_dir).unwrap();
     signed_secret_key
-        .public_key()
-        .sign(&signed_secret_key, || password.to_owned())
-        .unwrap()
+        .to_public_key()
         .to_armored_writer(&mut pubkey, Default::default())
         .unwrap();
 


### PR DESCRIPTION
This bumps to latest pgp/rsa/sha2 crates, finishing the update from https://github.com/rust-lang/promote-release/pull/103. We still depend on an old rand due to pgp having a stale dependency.

This also adds unit test coverage for the signing flow outside the full integration tests, helping with local testing. As part of adding those tests it identified a bug in the Git tag signing flow (existing since it was added in 2022) which should be fixed by the last commit.