### PR TITLE
Really stop recompressing to-be-pruned artifacts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -180,15 +180,6 @@ impl Context {
 
         self.assert_all_components_present()?;
 
-        // Produce a full set of artifacts so that pruning works correctly.
-        //
-        // Nightly (1.71+) supports this upstream without the extra recompression, see
-        // https://github.com/rust-lang/rust/pull/110436. We expect that this snippet can be fully
-        // dropped once that PR hits stable.
-        if self.config.channel != Channel::Nightly {
-            self.recompress(&self.dl_dir())?;
-        }
-
         // Ok we've now determined that a release needs to be done.
 
         let mut signer = Signer::new(&self.config)?;
@@ -208,9 +199,7 @@ impl Context {
 
         // Generate recompressed artifacts from the input set. This invalidates signatures etc
         // produced in the earlier step so we'll need to re-run the manifest building.
-        if self.config.channel == Channel::Nightly {
-            self.recompress(&self.dl_dir())?;
-        }
+        self.recompress(&self.dl_dir())?;
 
         // Since we recompressed, need to clear out the checksum cache.
         build_manifest.clear_checksum_cache()?;


### PR DESCRIPTION
This was added as a temporary measure in a226029d5b because otherwise build-manifest failed to read version information, which resulted in the packages getting dropped. As of the mentioned PR (rust-lang/rust#110436) this is no longer an issue, and that PR has long reached all branches.

Empirically, we see in build metrics that nightly releases take around 1h50m, while beta and stable releases take above 3 hours. This is largely explained by extra recompression done in beta/stable releases today of files that subsequently are deleted in `prune_unused_files`.

This also avoids having different code paths on different channels, which seems like a good win no matter what.