### PR TITLE
Update blog post generation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -292,14 +292,19 @@ impl Config {
             .map(|url| format!("You can leave feedback on the [internals thread]({url})."))
             .unwrap_or_default();
         let prefix = if for_blog {
+            let date_path = chrono::Utc::now().date_naive().format("%Y/%m/%d");
             format!(
-                r#"---
-layout: post
-title: "{} pre-release testing"
-author: Release automation
-team: The Release Team <https://www.rust-lang.org/governance/teams/release>
----{}"#,
-                release, "\n\n",
+                r#"+++
+path = "inside-rust/{date_path}/{release}-prerelease"
+title = "{release} pre-release testing"
+authors = ["Release automation"]
+
+[extra]
+team = "the Release team"
+team_url = "https://www.rust-lang.org/governance/teams/infra#team-release"
++++
+
+"#,
             )
         } else {
             String::new()
@@ -310,7 +315,7 @@ team: The Release Team <https://www.rust-lang.org/governance/teams/release>
 
 You can try it out locally by running:
 
-```plain
+```
 RUSTUP_DIST_SERVER=https://dev-static.rust-lang.org rustup update stable
 ```
 
@@ -323,7 +328,7 @@ we'd love your feedback [on this GitHub issue][feedback].
 
 [relnotes]: {release_notes_url}
 [feedback]: https://github.com/rust-lang/release-team/issues/16
-    "
+"
         ))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -905,11 +905,7 @@ impl Context {
             let blog_repo = token.repository()?;
             token.create_file(
                 &blog_repo.default_branch,
-                &format!(
-                    "posts/inside-rust/{}-{}-prerelease.md",
-                    chrono::Utc::now().date_naive().format("%Y-%m-%d"),
-                    version,
-                ),
+                &format!("content/inside-rust/{version}-prerelease.md"),
                 &blog_contents,
             )?;
         } else if let Some(pr) = self.config.blog_pr {


### PR DESCRIPTION
The blog has undergone some changes. This is adapting the generated posts accordingly.

* Blog posts now live under `content/`, not `posts/`.
* They don't have the publish date in the file name anymore.
* The frontmatter is now in TOML, instead of YAML. ("+++" fences instead of "---")
* The expected content of the frontmatter has changed. (explicit URL path, team name and url separated, layout not necessary anymore etc.)

This also cleans up the generated markdown a little:

* Remove trailing whitespace on last line.
* Remove code block language "plain" which is not recognized by Zola.

closes #109