### PR TITLE
Split rustc promotion into a separate binary

### DIFF
--- a/src/bin/promote-release.rs
+++ b/src/bin/promote-release.rs
@@ -1,0 +1,14 @@
+use anyhow::Error;
+use promote_release::{Context, RustcConfig};
+use std::env;
+
+// Called as:
+//
+//  $prog work/dir
+fn main() -> Result<(), Error> {
+    let mut context = Context::new(
+        env::current_dir()?.join(env::args_os().nth(1).unwrap()),
+        RustcConfig::from_env()?,
+    )?;
+    context.run()
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,7 +78,7 @@ impl FromStr for Action {
     }
 }
 
-pub(crate) struct Config {
+pub struct RustcConfig {
     /// This is the action we're expecting to take.
     pub(crate) action: Action,
 
@@ -211,8 +211,8 @@ pub(crate) struct Config {
     pub(crate) invalidate_fastly: bool,
 }
 
-impl Config {
-    pub(crate) fn from_env() -> Result<Self, Error> {
+impl RustcConfig {
+    pub fn from_env() -> Result<Self, Error> {
         Ok(Self {
             action: default_env("ACTION", Action::PromoteRelease)?,
             bypass_startup_checks: bool_env("BYPASS_STARTUP_CHECKS")?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use std::{collections::HashSet, env};
 
 use crate::build_manifest::BuildManifest;
-use crate::config::{Channel, Config};
+use crate::config::Channel;
 use crate::sign::Signer;
 use crate::smoke_test::SmokeTester;
 use anyhow::Error;
@@ -30,30 +30,21 @@ use github::{CreateTag, Github};
 use serde::Deserialize;
 use tempfile::NamedTempFile;
 
+pub use crate::config::RustcConfig;
+
 const TARGET: &str = env!("TARGET");
 
-struct Context {
+pub struct Context {
     work: PathBuf,
     handle: Easy,
-    config: Config,
+    config: RustcConfig,
     date: String,
     current_version: Option<String>,
     current_cargo_version: Option<String>,
 }
 
-// Called as:
-//
-//  $prog work/dir
-fn main() -> Result<(), Error> {
-    let mut context = Context::new(
-        env::current_dir()?.join(env::args_os().nth(1).unwrap()),
-        Config::from_env()?,
-    )?;
-    context.run()
-}
-
 impl Context {
-    fn new(work: PathBuf, config: Config) -> Result<Self, Error> {
+    pub fn new(work: PathBuf, config: RustcConfig) -> Result<Self, Error> {
         let date = Utc::now().format("%Y-%m-%d").to_string();
 
         // Configure the right amount of Rayon threads.
@@ -71,7 +62,7 @@ impl Context {
         })
     }
 
-    fn run(&mut self) -> Result<(), Error> {
+    pub fn run(&mut self) -> Result<(), Error> {
         let _lock = self.lock()?;
         match self.config.action {
             config::Action::PromoteRelease => self.do_release()?,

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -16,7 +16,7 @@ use std::{
     time::Instant,
 };
 
-use crate::config::Config;
+use crate::config::RustcConfig;
 
 pub(crate) struct Signer {
     gpg_key: SignedSecretKey,
@@ -35,7 +35,7 @@ impl Signer {
         })
     }
 
-    pub(crate) fn new(config: &Config) -> Result<Self, Error> {
+    pub(crate) fn new(config: &RustcConfig) -> Result<Self, Error> {
         Self::new_inner(
             Path::new(&config.gpg_key_file),
             Path::new(&config.gpg_password_file),


### PR DESCRIPTION
And turn the crate into a library, so that we can later add a promote-rustup binary.
